### PR TITLE
Force predicates to be managed as lowercase

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -107,9 +107,13 @@ ProblemExpert::getPredicates()
 bool
 ProblemExpert::addPredicate(const plansys2::Predicate & predicate)
 {
-  if (!existPredicate(predicate)) {
-    if (isValidPredicate(predicate)) {
-      predicates_.push_back(predicate);
+  plansys2::Predicate predicate_lower = predicate;
+  std::transform(predicate.name.begin(), predicate.name.end(), predicate_lower.name.begin(),
+    [](unsigned char c){ return std::tolower(c);});
+
+  if (!existPredicate(predicate_lower)) {
+    if (isValidPredicate(predicate_lower)) {
+      predicates_.push_back(predicate_lower);
       return true;
     } else {
       return false;
@@ -125,11 +129,15 @@ ProblemExpert::removePredicate(const plansys2::Predicate & predicate)
   bool found = false;
   int i = 0;
 
-  if (!isValidPredicate(predicate)) {  // if predicate is not valid, error
+  plansys2::Predicate predicate_lower = predicate;
+  std::transform(predicate.name.begin(), predicate.name.end(), predicate_lower.name.begin(),
+    [](unsigned char c){ return std::tolower(c);});
+
+  if (!isValidPredicate(predicate_lower)) {  // if predicate is not valid, error
     return false;
   }
   while (!found && i < predicates_.size()) {
-    if (parser::pddl::checkNodeEquality(predicates_[i], predicate)) {
+    if (parser::pddl::checkNodeEquality(predicates_[i], predicate_lower)) {
       found = true;
       predicates_.erase(predicates_.begin() + i);
     }
@@ -142,8 +150,12 @@ ProblemExpert::removePredicate(const plansys2::Predicate & predicate)
 std::optional<plansys2::Predicate>
 ProblemExpert::getPredicate(const std::string & expr)
 {
+  std::string expr_lower = expr;
+  std::transform(expr.begin(), expr.end(), expr_lower.begin(),
+    [](unsigned char c){ return std::tolower(c);});
+
   plansys2::Predicate ret;
-  plansys2::Predicate pred = parser::pddl::fromStringPredicate(expr);
+  plansys2::Predicate pred = parser::pddl::fromStringPredicate(expr_lower);
 
   bool found = false;
   size_t i = 0;


### PR DESCRIPTION
Hi,

This PR fixes #125

@jjzapf, what do you think about this bug? You contributed recently to this part, and maybe you know this part better than me.

* Do you think that this is the best solution? We are making an extra copy. Maybe it is not good from the efficiency point of view.
* Do you suggest any better fix?
* Do you think that this should also be fixed for instances and functions?

Thanks!!

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>