### PR TITLE
Expose lifecyclemanager timeout as a parameter, other misc fixes/features

### DIFF
--- a/plansys2_bringup/src/plansys2_node.cpp
+++ b/plansys2_bringup/src/plansys2_node.cpp
@@ -59,12 +59,14 @@ int main(int argc, char ** argv)
     exe.add_node(manager_node.second);
   }
 
-  std::shared_future<void> script = std::async(
+  std::shared_future<bool> script = std::async(
     std::launch::async,
     std::bind(plansys2::startup_script, manager_nodes));
   exe.spin_until_future_complete(script);
 
-  exe.spin();
+  if (script.get()) {
+    exe.spin();
+  }
 
   rclcpp::shutdown();
 

--- a/plansys2_bringup/src/plansys2_node.cpp
+++ b/plansys2_bringup/src/plansys2_node.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
 
   std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_function, manager_nodes));
+    std::bind(plansys2::startup_function, manager_nodes, std::chrono::seconds(5)));
   exe.spin_until_future_complete(startup_future);
 
   if (startup_future.get()) {

--- a/plansys2_bringup/src/plansys2_node.cpp
+++ b/plansys2_bringup/src/plansys2_node.cpp
@@ -66,13 +66,13 @@ int main(int argc, char ** argv)
 
   if (startup_future.get()) {
     exe.spin();
+    rclcpp::shutdown();
+    return 0;
   } else {
     RCLCPP_ERROR(
       rclcpp::get_logger("plansys2_bringup"),
       "Failed to start plansys2!");
+    rclcpp::shutdown();
+    return -1;
   }
-
-  rclcpp::shutdown();
-
-  return 0;
 }

--- a/plansys2_bringup/src/plansys2_node.cpp
+++ b/plansys2_bringup/src/plansys2_node.cpp
@@ -59,13 +59,17 @@ int main(int argc, char ** argv)
     exe.add_node(manager_node.second);
   }
 
-  std::shared_future<bool> script = std::async(
+  std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_script, manager_nodes));
-  exe.spin_until_future_complete(script);
+    std::bind(plansys2::startup_function, manager_nodes));
+  exe.spin_until_future_complete(startup_future);
 
-  if (script.get()) {
+  if (startup_future.get()) {
     exe.spin();
+  } else {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("plansys2_bringup"),
+      "Failed to start plansys2!");
   }
 
   rclcpp::shutdown();

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -39,7 +39,7 @@ public:
   using GoalHandleExecutePlan = rclcpp_action::ClientGoalHandle<ExecutePlan>;
 
   ExecutorClient();
-  explicit ExecutorClient(const std::string & node_name);  // I added this
+  explicit ExecutorClient(const std::string & node_name);
 
   bool start_plan_execution(const plansys2_msgs::msg::Plan & plan);
   bool execute_and_check_plan();

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -39,7 +39,7 @@ public:
   using GoalHandleExecutePlan = rclcpp_action::ClientGoalHandle<ExecutePlan>;
 
   ExecutorClient();
-  explicit ExecutorClient(const std::string & node_name);
+  explicit ExecutorClient(const std::string & node_name);  // I added this
 
   bool start_plan_execution(const plansys2_msgs::msg::Plan & plan);
   bool execute_and_check_plan();

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -39,6 +39,7 @@ public:
   using GoalHandleExecutePlan = rclcpp_action::ClientGoalHandle<ExecutePlan>;
 
   ExecutorClient();
+  ExecutorClient(const std::string & node_name);
 
   bool start_plan_execution(const plansys2_msgs::msg::Plan & plan);
   bool execute_and_check_plan();

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -63,7 +63,7 @@ private:
 
   bool goal_result_available_{false};
 
-  bool executing_plan_;
+  bool executing_plan_{false};
 
   void result_callback(const GoalHandleExecutePlan::WrappedResult & result);
   void feedback_callback(

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -39,7 +39,7 @@ public:
   using GoalHandleExecutePlan = rclcpp_action::ClientGoalHandle<ExecutePlan>;
 
   ExecutorClient();
-  ExecutorClient(const std::string & node_name);
+  explicit ExecutorClient(const std::string & node_name);
 
   bool start_plan_execution(const plansys2_msgs::msg::Plan & plan);
   bool execute_and_check_plan();

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -40,6 +40,17 @@ ExecutorClient::ExecutorClient()
   get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("executor/get_plan");
 }
 
+ExecutorClient::ExecutorClient(const std::string & node_name)
+{
+  node_ = rclcpp::Node::make_shared(node_name);
+
+  createActionClient();
+
+  get_ordered_sub_goals_client_ = node_->create_client<plansys2_msgs::srv::GetOrderedSubGoals>(
+    "executor/get_ordered_sub_goals");
+  get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("executor/get_plan");
+}
+
 void
 ExecutorClient::createActionClient()
 {

--- a/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
+++ b/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
@@ -69,7 +69,9 @@ private:
 };
 
 bool
-startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes);
+startup_function(
+    std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
+    std::chrono::seconds timeout);
 
 }  // namespace plansys2
 

--- a/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
+++ b/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
@@ -70,8 +70,8 @@ private:
 
 bool
 startup_function(
-    std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
-    std::chrono::seconds timeout);
+  std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
+  std::chrono::seconds timeout);
 
 }  // namespace plansys2
 

--- a/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
+++ b/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
@@ -68,7 +68,7 @@ private:
   std::string managed_node_;
 };
 
-void
+bool
 startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes);
 
 }  // namespace plansys2

--- a/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
+++ b/plansys2_lifecycle_manager/include/plansys2_lifecycle_manager/lifecycle_manager.hpp
@@ -69,7 +69,7 @@ private:
 };
 
 bool
-startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes);
+startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes);
 
 }  // namespace plansys2
 

--- a/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
+++ b/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
@@ -43,10 +43,16 @@ int main(int argc, char ** argv)
     exe.add_node(manager_node.second);
   }
 
-  std::shared_future<bool> script = std::async(
+  std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_script, manager_nodes));
-  exe.spin_until_future_complete(script);
+    std::bind(plansys2::startup_function, manager_nodes));
+  exe.spin_until_future_complete(startup_future);
+
+  if (!startup_future.get()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("plansys2_lifecycle_manager"),
+      "Failed to start plansys2!");
+  }
 
   rclcpp::shutdown();
 

--- a/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
+++ b/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ int main(int argc, char ** argv)
 
   std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_function, manager_nodes));
+    std::bind(plansys2::startup_function, manager_nodes, std::chrono::seconds(5)));
   exe.spin_until_future_complete(startup_future);
 
   if (!startup_future.get()) {

--- a/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
+++ b/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
@@ -1,4 +1,4 @@
-
+// Copyright 2016 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
+++ b/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
@@ -43,7 +43,7 @@ int main(int argc, char ** argv)
     exe.add_node(manager_node.second);
   }
 
-  std::shared_future<void> script = std::async(
+  std::shared_future<bool> script = std::async(
     std::launch::async,
     std::bind(plansys2::startup_script, manager_nodes));
   exe.spin_until_future_complete(script);

--- a/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
+++ b/plansys2_lifecycle_manager/src/lifecycle_manager_node.cpp
@@ -52,6 +52,8 @@ int main(int argc, char ** argv)
     RCLCPP_ERROR(
       rclcpp::get_logger("plansys2_lifecycle_manager"),
       "Failed to start plansys2!");
+    rclcpp::shutdown();
+    return -1;
   }
 
   rclcpp::shutdown();

--- a/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
+++ b/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
@@ -120,7 +120,7 @@ LifecycleServiceClient::change_state(std::uint8_t transition, std::chrono::secon
   }
 }
 
-void
+bool
 startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes)
 {
   // configure domain_expert
@@ -128,7 +128,7 @@ startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & 
     if (!manager_nodes["domain_expert"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
     {
-      return;
+      return false;
     }
 
     while (manager_nodes["domain_expert"]->get_state() !=
@@ -143,7 +143,7 @@ startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & 
     if (!manager_nodes["problem_expert"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
     {
-      return;
+      return false;
     }
 
     while (manager_nodes["problem_expert"]->get_state() !=
@@ -158,7 +158,7 @@ startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & 
     if (!manager_nodes["planner"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
     {
-      return;
+      return false;
     }
 
     while (manager_nodes["planner"]->get_state() !=
@@ -173,7 +173,7 @@ startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & 
     if (!manager_nodes["executor"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
     {
-      return;
+      return false;
     }
 
     while (manager_nodes["executor"]->get_state() !=
@@ -186,41 +186,42 @@ startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & 
   // activate
   {
     if (!rclcpp::ok()) {
-      return;
+      return false;
     }
     if (!manager_nodes["domain_expert"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
     {
-      return;
+      return false;
     }
     if (!manager_nodes["problem_expert"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
     {
-      return;
+      return false;
     }
     if (!manager_nodes["planner"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
     {
-      return;
+      return false;
     }
     if (!manager_nodes["executor"]->change_state(
         lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
     {
-      return;
+      return false;
     }
     if (!manager_nodes["domain_expert"]->get_state()) {
-      return;
+      return false;
     }
     if (!manager_nodes["problem_expert"]->get_state()) {
-      return;
+      return false;
     }
     if (!manager_nodes["planner"]->get_state()) {
-      return;
+      return false;
     }
     if (!manager_nodes["executor"]->get_state()) {
-      return;
+      return false;
     }
   }
+  return true;
 }
 
 }  // namespace plansys2

--- a/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
+++ b/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
@@ -121,7 +121,7 @@ LifecycleServiceClient::change_state(std::uint8_t transition, std::chrono::secon
 }
 
 bool
-startup_script(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes)
+startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes)
 {
   // configure domain_expert
   {

--- a/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
+++ b/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
@@ -121,12 +121,15 @@ LifecycleServiceClient::change_state(std::uint8_t transition, std::chrono::secon
 }
 
 bool
-startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes)
+startup_function(
+    std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
+    std::chrono::seconds timeout)
 {
   // configure domain_expert
   {
     if (!manager_nodes["domain_expert"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+        timeout))
     {
       return false;
     }
@@ -141,7 +144,8 @@ startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> 
   // configure problem_expert
   {
     if (!manager_nodes["problem_expert"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+        timeout))
     {
       return false;
     }
@@ -156,7 +160,8 @@ startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> 
   // configure planner
   {
     if (!manager_nodes["planner"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+        timeout))
     {
       return false;
     }
@@ -171,7 +176,8 @@ startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> 
   // configure executor
   {
     if (!manager_nodes["executor"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+        timeout))
     {
       return false;
     }
@@ -189,22 +195,26 @@ startup_function(std::map<std::string, std::shared_ptr<LifecycleServiceClient>> 
       return false;
     }
     if (!manager_nodes["domain_expert"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE,
+        timeout))
     {
       return false;
     }
     if (!manager_nodes["problem_expert"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE,
+        timeout))
     {
       return false;
     }
     if (!manager_nodes["planner"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE,
+        timeout))
     {
       return false;
     }
     if (!manager_nodes["executor"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE,
+        timeout))
     {
       return false;
     }

--- a/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
+++ b/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
@@ -122,8 +122,8 @@ LifecycleServiceClient::change_state(std::uint8_t transition, std::chrono::secon
 
 bool
 startup_function(
-    std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
-    std::chrono::seconds timeout)
+  std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
+  std::chrono::seconds timeout)
 {
   // configure domain_expert
   {

--- a/plansys2_lifecycle_manager/test/lf_manager_test.cpp
+++ b/plansys2_lifecycle_manager/test/lf_manager_test.cpp
@@ -118,7 +118,7 @@ TEST(lifecycle_manager, lf_startup)
 
   std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_function, manager_nodes));
+    std::bind(plansys2::startup_function, manager_nodes, std::chrono::seconds(3)));
 
   startup_future.wait();
 

--- a/plansys2_lifecycle_manager/test/lf_manager_test.cpp
+++ b/plansys2_lifecycle_manager/test/lf_manager_test.cpp
@@ -67,7 +67,7 @@ TEST(lifecycle_manager, lf_client)
   t.join();
 }
 
-TEST(lifecycle_manager, lf_script)
+TEST(lifecycle_manager, lf_startup)
 {
   auto de_node = rclcpp_lifecycle::LifecycleNode::make_shared("domain_expert");
   auto pe_node = rclcpp_lifecycle::LifecycleNode::make_shared("problem_expert");
@@ -116,11 +116,11 @@ TEST(lifecycle_manager, lf_script)
       while (!finish) {exe.spin_some();}
     });
 
-  std::shared_future<bool> script = std::async(
+  std::shared_future<bool> startup_future = std::async(
     std::launch::async,
-    std::bind(plansys2::startup_script, manager_nodes));
+    std::bind(plansys2::startup_function, manager_nodes));
 
-  script.wait();
+  startup_future.wait();
 
   ASSERT_EQ(
     de_node->get_current_state().id(),

--- a/plansys2_lifecycle_manager/test/lf_manager_test.cpp
+++ b/plansys2_lifecycle_manager/test/lf_manager_test.cpp
@@ -116,7 +116,7 @@ TEST(lifecycle_manager, lf_script)
       while (!finish) {exe.spin_some();}
     });
 
-  std::shared_future<void> script = std::async(
+  std::shared_future<bool> script = std::async(
     std::launch::async,
     std::bind(plansys2::startup_script, manager_nodes));
 


### PR DESCRIPTION
Summary of changes
* fix #229 
* expose lifecycle manager timeout as a parameter in the bringup files
* the launch files now exit with a failure if they can't bring up the nodes
* added a ctor to ExecutorClient to enable unique node naming