### PR TITLE
Domain validation fix

### DIFF
--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -150,8 +150,9 @@ POPFPlanSolver::is_valid_domain(
 
   std::string result((std::istreambuf_iterator<char>(plan_file)),
     std::istreambuf_iterator<char>());
+  std::transform(result.begin(), result.end(), result.begin(), ::tolower);//result output plan to lower case
 
-  return result.find("Solution Found") != result.npos;
+  return result.find("error") == result.npos;//no "error" string in output from the planner -> domain valid
 }
 
 }  // namespace plansys2

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <algorithm>
 
 #include "plansys2_msgs/msg/plan_item.hpp"
 #include "plansys2_popf_plan_solver/popf_plan_solver.hpp"
@@ -150,9 +151,11 @@ POPFPlanSolver::is_valid_domain(
 
   std::string result((std::istreambuf_iterator<char>(plan_file)),
     std::istreambuf_iterator<char>());
-  std::transform(result.begin(), result.end(), result.begin(), ::tolower);//result output plan to lower case
+  // result output plan to lower case
+  std::transform(result.begin(), result.end(), result.begin(), ::tolower);
 
-  return result.find("error") == result.npos;//no "error" string in output from the planner -> domain valid
+  // no "error" string in output from the planner -> domain valid
+  return result.find("error") == result.npos;
 }
 
 }  // namespace plansys2


### PR DESCRIPTION
With problem void, planner should return empty string not containing errors if the domain file is valid and cannot contain "Solution found"as it was check before

Edit: close issue #232 when accepted