### PR TITLE
Reverting is_valid_domain in popf_plan_solver back to its original fu…

### DIFF
--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -151,7 +151,7 @@ POPFPlanSolver::is_valid_domain(
   std::string result((std::istreambuf_iterator<char>(plan_file)),
     std::istreambuf_iterator<char>());
 
-  return result.find("Solution Found") != result.npos;
+  return result.empty();
 }
 
 }  // namespace plansys2


### PR DESCRIPTION
The check_domain function in popf_plan_solver.cpp was recently changed and renamed to is_valid_domain. The DomainExpertNode calls this function in the on_configure callback. Previously, a failure would occur if the returned string was not empty. Now a failure will occur if the string does not contain "Solution Found". If the string is supposed to be empty, how can it contain "Solution Found"? Has something changed in the implementation such that the string should no longer be empty?  For my examples, the string still appears to be empty.

Making the suggested change in this MR should revert the code back to it's previous logic. Without this change my previously working examples no longer work. ... I'm not really sure how this part of the code was intended to work, so my fix my not be the best solution. BTW, I am running Foxy, not Humble.