### PR TITLE
[problem_expert] AddInstance successeeds if instance already exists

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -41,14 +41,13 @@ ProblemExpert::ProblemExpert(std::shared_ptr<DomainExpert> & domain_expert)
 bool
 ProblemExpert::addInstance(const plansys2::Instance & instance)
 {
-  if (!isValidType(instance.type)) {
+  if (!isValidType(instance.type))
     return false;
-  } else if (existInstance(instance.name)) {
-    return false;
-  } else {
+
+  if (!existInstance(instance.name))
     instances_.push_back(instance);
+
     return true;
-  }
 }
 
 std::vector<plansys2::Instance>


### PR DESCRIPTION
When adding an instance ( for example, through a service call to "problem_expert/add_problem_instance") , if the instance **already exists** we return false. This in turn causes the service to reply in failure with an error "instance not valid". This is both incorrect as well as inconsistent with how adding a predicate is handled. This PR fix that inconsistency and considers the service call successful if the instance is already there.

```cpp
ProblemExpertNode::add_problem_instance_service_callback( 
.....
   } else {                                                                    
       response->error_info = "Instance not valid";                              
     }
  .... 
 ```
 
 Changelog
 * FIX: [problem_expert] AddInstance successeeds if instance already exists