### PR TITLE
Fixes for bt_actions and popf_plan_sover

### DIFF
--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -120,6 +120,7 @@ public:
   virtual void on_feedback(
     const std::shared_ptr<const typename ActionT::Feedback> feedback)
   {
+    (void)feedback;
   }
 
   // Called upon successful completion of the action. A derived class can override this


### PR DESCRIPTION
* solves #232
* solves issue in BTAction.cpp where loggers created during activation were not deleted during deactivation
* add try/catch to BT construction in BTAction.cpp
* (void) feedback in BtActionNode so that everyone's linters stop complaining