### PR TITLE
New BT Builder and Plugin Interface

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -72,7 +72,7 @@ def generate_launch_description():
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
         "bt_builder_plugin",
-        default_value="STNBTBuilder",
+        default_value="SimpleBTBuilder",
         description="Behavior tree builder plugin.",
     )
 

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -30,7 +30,10 @@ def generate_launch_description():
     model_file = LaunchConfiguration('model_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
-    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
+    action_bt_file = LaunchConfiguration('action_bt_file')
+    start_action_bt_file = LaunchConfiguration('start_action_bt_file')
+    end_action_bt_file = LaunchConfiguration('end_action_bt_file')
+    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
 
     declare_model_file_cmd = DeclareLaunchArgument(
         'model_file',
@@ -46,12 +49,32 @@ def generate_launch_description():
         default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
-    declare_default_bt_file_cmd = DeclareLaunchArgument(
-        'default_action_bt_xml_filename',
+    declare_action_bt_file_cmd = DeclareLaunchArgument(
+        'action_bt_file',
         default_value=os.path.join(
           get_package_share_directory('plansys2_executor'),
           'behavior_trees', 'plansys2_action_bt.xml'),
         description='BT representing a PDDL action')
+
+    declare_start_action_bt_file_cmd = DeclareLaunchArgument(
+        'start_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_start_action_bt.xml'),
+        description='BT representing a PDDL start action')
+
+    declare_end_action_bt_file_cmd = DeclareLaunchArgument(
+        'end_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_end_action_bt.xml'),
+        description='BT representing a PDDL end action')
+
+    declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
+        "bt_builder_plugin",
+        default_value="STNBTBuilder",
+        description="Behavior tree builder plugin.",
+    )
 
     domain_expert_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(os.path.join(
@@ -93,7 +116,10 @@ def generate_launch_description():
         launch_arguments={
           'namespace': namespace,
           'params_file': params_file,
-          'default_action_bt_xml_filename': default_action_bt_xml_filename
+          'default_action_bt_xml_filename': action_bt_file,
+          'default_start_action_bt_xml_filename': start_action_bt_file,
+          'default_end_action_bt_xml_filename': end_action_bt_file,
+          'bt_builder_plugin': bt_builder_plugin,
         }.items())
 
     lifecycle_manager_cmd = Node(
@@ -108,7 +134,10 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_model_file_cmd)
-    ld.add_action(declare_default_bt_file_cmd)
+    ld.add_action(declare_action_bt_file_cmd)
+    ld.add_action(declare_start_action_bt_file_cmd)
+    ld.add_action(declare_end_action_bt_file_cmd)
+    ld.add_action(declare_bt_builder_plugin_cmd)
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_params_file_cmd)
 

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -72,7 +72,7 @@ def generate_launch_description():
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
         "bt_builder_plugin",
-        default_value="STNBTBuilder",
+        default_value="SimpleBTBuilder",
         description="Behavior tree builder plugin.",
     )
 

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -30,7 +30,10 @@ def generate_launch_description():
     model_file = LaunchConfiguration('model_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
-    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
+    action_bt_file = LaunchConfiguration('action_bt_file')
+    start_action_bt_file = LaunchConfiguration("start_action_bt_file")
+    end_action_bt_file = LaunchConfiguration("end_action_bt_file")
+    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
 
     declare_model_file_cmd = DeclareLaunchArgument(
         'model_file',
@@ -46,12 +49,32 @@ def generate_launch_description():
         default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
-    declare_default_bt_file_cmd = DeclareLaunchArgument(
-        'default_action_bt_xml_filename',
+    declare_action_bt_file_cmd = DeclareLaunchArgument(
+        'action_bt_file',
         default_value=os.path.join(
           get_package_share_directory('plansys2_executor'),
           'behavior_trees', 'plansys2_action_bt.xml'),
         description='BT representing a PDDL action')
+
+    declare_start_action_bt_file_cmd = DeclareLaunchArgument(
+        'start_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_start_action_bt.xml'),
+        description='BT representing a PDDL start action')
+
+    declare_end_action_bt_file_cmd = DeclareLaunchArgument(
+        'end_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_end_action_bt.xml'),
+        description='BT representing a PDDL end action')
+
+    declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
+        "bt_builder_plugin",
+        default_value="STNBTBuilder",
+        description="Behavior tree builder plugin.",
+    )
 
     plansys2_node_cmd = Node(
         package='plansys2_bringup',
@@ -61,7 +84,10 @@ def generate_launch_description():
         parameters=[
           {
             'model_file': model_file,
-            'default_action_bt_xml_filename': default_action_bt_xml_filename
+            'default_action_bt_xml_filename': action_bt_file,
+            'default_start_action_bt_xml_filename': start_action_bt_file,
+            'default_end_action_bt_xml_filename': end_action_bt_file,
+            'bt_builder_plugin': bt_builder_plugin,
           },
           params_file
         ])
@@ -70,7 +96,10 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_model_file_cmd)
-    ld.add_action(declare_default_bt_file_cmd)
+    ld.add_action(declare_action_bt_file_cmd)
+    ld.add_action(declare_start_action_bt_file_cmd)
+    ld.add_action(declare_end_action_bt_file_cmd)
+    ld.add_action(declare_bt_builder_plugin_cmd)
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_params_file_cmd)
 

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_domain_expert REQUIRED)
 find_package(plansys2_problem_expert REQUIRED)
 find_package(plansys2_planner REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(std_msgs REQUIRED)
 
@@ -43,6 +44,7 @@ set(dependencies
     plansys2_domain_expert
     plansys2_problem_expert
     plansys2_planner
+    pluginlib
     behaviortree_cpp_v3
     std_msgs
 )
@@ -54,9 +56,9 @@ set(EXECUTOR_SOURCES
   src/plansys2_executor/ActionExecutor.cpp
   src/plansys2_executor/ActionExecutorClient.cpp
   src/plansys2_executor/ExecutorNode.cpp
-  src/plansys2_executor/BTBuilder.cpp
   src/plansys2_executor/behavior_tree/execute_action_node.cpp
   src/plansys2_executor/behavior_tree/wait_action_node.cpp
+  src/plansys2_executor/behavior_tree/check_action_node.cpp
   src/plansys2_executor/behavior_tree/wait_atstart_req_node.cpp
   src/plansys2_executor/behavior_tree/check_overall_req_node.cpp
   src/plansys2_executor/behavior_tree/check_atend_req_node.cpp
@@ -80,10 +82,19 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+add_library(bt_builder_plugins SHARED
+  src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+  src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
+)
+ament_target_dependencies(bt_builder_plugins ${dependencies})
+
+pluginlib_export_plugin_description_file(plansys2_executor plugins.xml)
+
 install(DIRECTORY launch behavior_trees DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
   ${PROJECT_NAME}
+  bt_builder_plugins
   executor_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -100,7 +111,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME} bt_builder_plugins)
 ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_executor/behavior_trees/plansys2_end_action_bt.xml
+++ b/plansys2_executor/behavior_trees/plansys2_end_action_bt.xml
@@ -1,12 +1,9 @@
 <Sequence name="ACTION_ID">
-WAIT_PREV_ACTIONS
-  <WaitAtStartReq action="ACTION_ID"/>
-  <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
-    <CheckTimeout action="ACTION_ID"/>
     <CheckOverAllReq action="ACTION_ID"/>
     <ExecuteAction action="ACTION_ID"/>
   </ReactiveSequence>
+CHECK_PREV_ACTIONS
   <CheckAtEndReq action="ACTION_ID"/>
   <ApplyAtEndEffect action="ACTION_ID"/>
 </Sequence>

--- a/plansys2_executor/behavior_trees/plansys2_start_action_bt.xml
+++ b/plansys2_executor/behavior_trees/plansys2_start_action_bt.xml
@@ -1,0 +1,5 @@
+<Sequence name="ACTION_ID">
+WAIT_PREV_ACTIONS
+  <WaitAtStartReq action="ACTION_ID"/>
+  <ApplyAtStartEffect action="ACTION_ID"/>
+</Sequence>

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -15,157 +15,90 @@
 #ifndef PLANSYS2_EXECUTOR__BTBUILDER_HPP_
 #define PLANSYS2_EXECUTOR__BTBUILDER_HPP_
 
-#include <string>
-#include <memory>
-#include <vector>
-#include <set>
-#include <list>
 #include <map>
-#include <utility>
-#include <tuple>
+#include <memory>
+#include <string>
 
-#include "std_msgs/msg/empty.hpp"
-
-#include "plansys2_domain_expert/DomainExpertClient.hpp"
-#include "plansys2_problem_expert/ProblemExpertClient.hpp"
 #include "plansys2_executor/ActionExecutor.hpp"
-#include "plansys2_core/Types.hpp"
-#include "plansys2_msgs/msg/durative_action.hpp"
 #include "plansys2_msgs/msg/plan.hpp"
-
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
 
 namespace plansys2
 {
 
+enum struct ActionType
+{
+  UNKNOWN,
+  INIT,
+  DURATIVE,
+  START,
+  OVERALL,
+  END,
+  GOAL
+};
+
 struct ActionStamped
 {
   float time;
+  std::string expression;
   float duration;
+  ActionType type;
   std::shared_ptr<plansys2_msgs::msg::DurativeAction> action;
-};
 
-struct GraphNode
-{
-  using Ptr = std::shared_ptr<GraphNode>;
-  static Ptr make_shared() {return std::make_shared<GraphNode>();}
-
-  ActionStamped action;
-  int node_num;
-  int level_num;
-
-  std::vector<plansys2::Predicate> predicates;
-  std::vector<plansys2::Function> functions;
-
-  std::list<GraphNode::Ptr> in_arcs;
-  std::list<GraphNode::Ptr> out_arcs;
-};
-
-struct Graph
-{
-  using Ptr = std::shared_ptr<Graph>;
-  static Ptr make_shared() {return std::make_shared<Graph>();}
-
-  std::list<GraphNode::Ptr> roots;
-  std::map<float, std::list<GraphNode::Ptr>> levels;
+  ActionStamped()
+  : time(0.0), duration(0.0) {}
 };
 
 class BTBuilder
 {
 public:
-  explicit BTBuilder(rclcpp::Node::SharedPtr node, const std::string & bt_action = "");
+  using Ptr = std::shared_ptr<plansys2::BTBuilder>;
 
-  Graph::Ptr get_graph(const plansys2_msgs::msg::Plan & current_plan);
-  std::string get_tree(const plansys2_msgs::msg::Plan & current_plan);
-  std::string get_dotgraph(
-    Graph::Ptr action_graph, std::shared_ptr<std::map<std::string,
-    ActionExecutionInfo>> action_map, bool enable_legend = false,
-    bool enable_print_graph = false);
+  virtual void initialize(
+    const std::string & bt_action_1 = "",
+    const std::string & bt_action_2 = "",
+    int precision = 3) = 0;
 
-protected:
-  std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
-  std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
+  virtual std::string get_tree(const plansys2_msgs::msg::Plan & current_plan) = 0;
+  virtual std::string get_dotgraph(
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map,
+    bool enable_legend = false,
+    bool enable_print_graph = false) = 0;
 
-  std::string bt_action_;
+  static int to_int_time(float time, int power)
+  {
+    float scale = pow(10.0, static_cast<float>(power));
+    return static_cast<int>(time * scale);
+  }
 
-  std::vector<ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan);
-  void prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy);
-  void prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & used_nodes);
-  void get_state(
-    const GraphNode::Ptr & node,
-    std::list<GraphNode::Ptr> & used_nodes,
-    std::vector<plansys2::Predicate> & predicates,
-    std::vector<plansys2::Function> & functions) const;
+  static std::string to_string(const ActionType & action_type)
+  {
+    switch (action_type) {
+      case ActionType::INIT:
+        return "INIT";
+      case ActionType::DURATIVE:
+        return "DURATIVE";
+      case ActionType::START:
+        return "START";
+      case ActionType::OVERALL:
+        return "OVERALL";
+      case ActionType::END:
+        return "END";
+      case ActionType::GOAL:
+        return "GOAL";
+      default:
+        return "UNKNOWN";
+    }
+  }
 
-  bool is_action_executable(
-    const ActionStamped & action,
-    std::vector<plansys2::Predicate> & predicates,
-    std::vector<plansys2::Function> & functions) const;
-  std::list<GraphNode::Ptr> get_roots(
-    std::vector<plansys2::ActionStamped> & action_sequence,
-    std::vector<plansys2::Predicate> & predicates,
-    std::vector<plansys2::Function> & functions,
-    int & node_counter);
-  GraphNode::Ptr get_node_satisfy(
-    const plansys2_msgs::msg::Tree & requirement,
-    const Graph::Ptr & graph,
-    const GraphNode::Ptr & current);
-  GraphNode::Ptr get_node_satisfy(
-    const plansys2_msgs::msg::Tree & requirement,
-    const GraphNode::Ptr & node,
-    const GraphNode::Ptr & current);
-  std::list<GraphNode::Ptr> get_node_contradict(
-    const Graph::Ptr & graph,
-    const GraphNode::Ptr & current);
-  void get_node_contradict(
-    const GraphNode::Ptr & node,
-    const GraphNode::Ptr & current,
-    std::list<GraphNode::Ptr> & parents);
-  void remove_existing_requirements(
-    std::vector<plansys2_msgs::msg::Tree> & requirements,
-    std::vector<plansys2::Predicate> & predicates,
-    std::vector<plansys2::Function> & functions) const;
-  bool is_parallelizable(
-    const plansys2::ActionStamped & action,
-    const std::vector<plansys2::Predicate> & predicates,
-    const std::vector<plansys2::Function> & functions,
-    const std::list<GraphNode::Ptr> & ret) const;
+  static std::string to_action_id(const plansys2_msgs::msg::PlanItem & item, int precision)
+  {
+    return item.action + ":" + std::to_string(to_int_time(item.time, precision));
+  }
 
-  std::string get_flow_tree(
-    GraphNode::Ptr node,
-    std::list<std::string> & used_nodes,
-    int level = 0);
-  void get_flow_dotgraph(GraphNode::Ptr node, std::set<std::string> & edges);
-  std::string get_node_dotgraph(
-    GraphNode::Ptr node, std::shared_ptr<std::map<std::string,
-    ActionExecutionInfo>> action_map, int level = 0);
-  ActionExecutor::Status get_action_status(
-    ActionStamped action,
-    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
-  void addDotGraphLegend(
-    std::stringstream & ss, int tab_level, int level_counter,
-    int node_counter);
-
-  std::string t(int level);
-
-  std::string execution_block(const GraphNode::Ptr & node, int l);
-  void print_node(
-    const GraphNode::Ptr & node,
-    int level,
-    std::set<GraphNode::Ptr> & used_nodes) const;
-
-  void print_graph(const plansys2::Graph::Ptr & graph) const;
-
-  void print_node_csv(const GraphNode::Ptr & node, uint32_t root_num) const;
-  void print_graph_csv(const plansys2::Graph::Ptr & graph) const;
-
-  void get_node_tabular(
-    const plansys2::GraphNode::Ptr & node,
-    uint32_t root_num,
-    std::vector<std::tuple<uint32_t, uint32_t, uint32_t, std::string>> & graph) const;
-  std::vector<std::tuple<uint32_t, uint32_t, uint32_t, std::string>> get_graph_tabular(
-    const plansys2::Graph::Ptr & graph) const;
+  static std::string to_action_id(const ActionStamped & action, int precision)
+  {
+    return action.expression + ":" + std::to_string(to_int_time(action.time, precision));
+  }
 };
 
 }  // namespace plansys2

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -24,6 +24,7 @@
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
 #include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_executor/ActionExecutor.hpp"
+#include "plansys2_executor/BTBuilder.hpp"
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
@@ -38,6 +39,9 @@
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "pluginlib/class_loader.hpp"
+#include "pluginlib/class_list_macros.hpp"
 
 namespace plansys2
 {
@@ -71,13 +75,15 @@ public:
 
 protected:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Node::SharedPtr aux_node_;
 
   bool cancel_plan_requested_;
   std::optional<plansys2_msgs::msg::Plan> current_plan_;
   std::optional<std::vector<plansys2_msgs::msg::Tree>> ordered_sub_goals_;
 
   std::string action_bt_xml_;
+  std::string start_action_bt_xml_;
+  std::string end_action_bt_xml_;
+  pluginlib::ClassLoader<plansys2::BTBuilder> bt_builder_loader_;
 
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;

--- a/plansys2_executor/include/plansys2_executor/behavior_tree/check_action_node.hpp
+++ b/plansys2_executor/include/plansys2_executor/behavior_tree/check_action_node.hpp
@@ -1,0 +1,56 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_EXECUTOR__BEHAVIOR_TREE__CHECK_ACTION_NODE_HPP_
+#define PLANSYS2_EXECUTOR__BEHAVIOR_TREE__CHECK_ACTION_NODE_HPP_
+
+#include <map>
+#include <string>
+#include <memory>
+
+
+#include "behaviortree_cpp_v3/action_node.h"
+
+#include "plansys2_executor/ActionExecutor.hpp"
+
+#include "plansys2_executor/behavior_tree/execute_action_node.hpp"
+
+namespace plansys2
+{
+
+class CheckAction : public BT::ActionNodeBase
+{
+public:
+  CheckAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf);
+
+  void halt() {}
+  BT::NodeStatus tick() override;
+
+  static BT::PortsList providedPorts()
+  {
+    return BT::PortsList(
+      {
+        BT::InputPort<std::string>("action", "Action to be executed"),
+      });
+  }
+
+private:
+  std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map_;
+};
+
+}  // namespace plansys2
+
+#endif  // PLANSYS2_EXECUTOR__BEHAVIOR_TREE__CHECK_ACTION_NODE_HPP_

--- a/plansys2_executor/include/plansys2_executor/bt_builder_plugins/simple_bt_builder.hpp
+++ b/plansys2_executor/include/plansys2_executor/bt_builder_plugins/simple_bt_builder.hpp
@@ -1,0 +1,179 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__SIMPLE_BT_BUILDER_HPP_
+#define PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__SIMPLE_BT_BUILDER_HPP_
+
+#include <string>
+#include <memory>
+#include <vector>
+#include <set>
+#include <list>
+#include <map>
+#include <utility>
+#include <tuple>
+
+#include "std_msgs/msg/empty.hpp"
+
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
+#include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include "plansys2_executor/ActionExecutor.hpp"
+#include "plansys2_executor/BTBuilder.hpp"
+#include "plansys2_core/Types.hpp"
+#include "plansys2_msgs/msg/durative_action.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+namespace plansys2
+{
+
+struct GraphNode
+{
+  using Ptr = std::shared_ptr<GraphNode>;
+  static Ptr make_shared() {return std::make_shared<GraphNode>();}
+
+  ActionStamped action;
+  int node_num;
+  int level_num;
+
+  std::vector<plansys2::Predicate> predicates;
+  std::vector<plansys2::Function> functions;
+
+  std::list<GraphNode::Ptr> in_arcs;
+  std::list<GraphNode::Ptr> out_arcs;
+};
+
+struct Graph
+{
+  using Ptr = std::shared_ptr<Graph>;
+  static Ptr make_shared() {return std::make_shared<Graph>();}
+
+  std::list<GraphNode::Ptr> roots;
+  std::map<float, std::list<GraphNode::Ptr>> levels;
+};
+
+class SimpleBTBuilder : public BTBuilder
+{
+public:
+  SimpleBTBuilder();
+  void initialize(
+    const std::string & bt_action_1 = "",
+    const std::string & bt_action_2 = "",
+    int precision = 3);
+
+  std::string get_tree(const plansys2_msgs::msg::Plan & current_plan);
+  std::string get_dotgraph(
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map,
+    bool enable_legend = false,
+    bool enable_print_graph = false);
+
+protected:
+  std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
+  std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
+
+  Graph::Ptr graph_;
+  std::string bt_;
+  std::string bt_action_;
+
+  Graph::Ptr get_graph(const plansys2_msgs::msg::Plan & current_plan);
+
+  std::vector<ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan);
+  void prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy);
+  void prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & used_nodes);
+  void get_state(
+    const GraphNode::Ptr & node,
+    std::list<GraphNode::Ptr> & used_nodes,
+    std::vector<plansys2::Predicate> & predicates,
+    std::vector<plansys2::Function> & functions) const;
+
+  bool is_action_executable(
+    const ActionStamped & action,
+    std::vector<plansys2::Predicate> & predicates,
+    std::vector<plansys2::Function> & functions) const;
+  std::list<GraphNode::Ptr> get_roots(
+    std::vector<plansys2::ActionStamped> & action_sequence,
+    std::vector<plansys2::Predicate> & predicates,
+    std::vector<plansys2::Function> & functions,
+    int & node_counter);
+  GraphNode::Ptr get_node_satisfy(
+    const plansys2_msgs::msg::Tree & requirement,
+    const Graph::Ptr & graph,
+    const GraphNode::Ptr & current);
+  GraphNode::Ptr get_node_satisfy(
+    const plansys2_msgs::msg::Tree & requirement,
+    const GraphNode::Ptr & node,
+    const GraphNode::Ptr & current);
+  std::list<GraphNode::Ptr> get_node_contradict(
+    const Graph::Ptr & graph,
+    const GraphNode::Ptr & current);
+  void get_node_contradict(
+    const GraphNode::Ptr & node,
+    const GraphNode::Ptr & current,
+    std::list<GraphNode::Ptr> & parents);
+  void remove_existing_requirements(
+    std::vector<plansys2_msgs::msg::Tree> & requirements,
+    std::vector<plansys2::Predicate> & predicates,
+    std::vector<plansys2::Function> & functions) const;
+  bool is_parallelizable(
+    const plansys2::ActionStamped & action,
+    const std::vector<plansys2::Predicate> & predicates,
+    const std::vector<plansys2::Function> & functions,
+    const std::list<GraphNode::Ptr> & ret) const;
+
+  std::string get_flow_tree(
+    GraphNode::Ptr node,
+    std::list<std::string> & used_nodes,
+    int level = 0);
+  void get_flow_dotgraph(GraphNode::Ptr node, std::set<std::string> & edges);
+  std::string get_node_dotgraph(
+    GraphNode::Ptr node, std::shared_ptr<std::map<std::string,
+    ActionExecutionInfo>> action_map, int level = 0);
+  ActionExecutor::Status get_action_status(
+    ActionStamped action,
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
+  void addDotGraphLegend(
+    std::stringstream & ss, int tab_level, int level_counter,
+    int node_counter);
+
+  std::string t(int level);
+
+  std::string execution_block(const GraphNode::Ptr & node, int l);
+  void print_node(
+    const GraphNode::Ptr & node,
+    int level,
+    std::set<GraphNode::Ptr> & used_nodes) const;
+
+  void print_graph(const plansys2::Graph::Ptr & graph) const;
+
+  void print_node_csv(const GraphNode::Ptr & node, uint32_t root_num) const;
+  void print_graph_csv(const plansys2::Graph::Ptr & graph) const;
+
+  void get_node_tabular(
+    const plansys2::GraphNode::Ptr & node,
+    uint32_t root_num,
+    std::vector<std::tuple<uint32_t, uint32_t, uint32_t, std::string>> & graph) const;
+  std::vector<std::tuple<uint32_t, uint32_t, uint32_t, std::string>> get_graph_tabular(
+    const plansys2::Graph::Ptr & graph) const;
+};
+
+}  // namespace plansys2
+
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(plansys2::SimpleBTBuilder, plansys2::BTBuilder)
+
+#endif  // PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__SIMPLE_BT_BUILDER_HPP_

--- a/plansys2_executor/include/plansys2_executor/bt_builder_plugins/stn_bt_builder.hpp
+++ b/plansys2_executor/include/plansys2_executor/bt_builder_plugins/stn_bt_builder.hpp
@@ -1,0 +1,196 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__STN_BT_BUILDER_HPP_
+#define PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__STN_BT_BUILDER_HPP_
+
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
+#include "plansys2_executor/ActionExecutor.hpp"
+#include "plansys2_executor/BTBuilder.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
+#include "plansys2_problem_expert/ProblemExpertClient.hpp"
+
+namespace plansys2
+{
+
+struct StateVec
+{
+  std::vector<plansys2::Predicate> predicates;
+  std::vector<plansys2::Function> functions;
+};
+
+struct GraphNode
+{
+  using Ptr = std::shared_ptr<GraphNode>;
+  static Ptr make_shared(int id) {return std::make_shared<GraphNode>(id);}
+
+  int node_num;
+  bool visited;
+  ActionStamped action;
+
+  std::set<std::tuple<GraphNode::Ptr, double, double>> input_arcs;
+  std::set<std::tuple<GraphNode::Ptr, double, double>> output_arcs;
+
+  explicit GraphNode(int id)
+  : node_num(id), visited(false) {}
+};
+
+struct Graph
+{
+  using Ptr = std::shared_ptr<Graph>;
+  static Ptr make_shared() {return std::make_shared<Graph>();}
+
+  std::list<GraphNode::Ptr> nodes;
+};
+
+class STNBTBuilder : public BTBuilder
+{
+public:
+  STNBTBuilder();
+  void initialize(
+    const std::string & bt_action_1 = "",
+    const std::string & bt_action_2 = "",
+    int precision = 3);
+
+  std::string get_tree(const plansys2_msgs::msg::Plan & current_plan);
+  std::string get_dotgraph(
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map,
+    bool enable_legend = false,
+    bool enable_print_graph = false);
+
+protected:
+  Graph::Ptr build_stn(const plansys2_msgs::msg::Plan & plan) const;
+  std::string build_bt(const Graph::Ptr stn) const;
+
+  Graph::Ptr init_graph(const plansys2_msgs::msg::Plan & plan) const;
+  std::vector<ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan) const;
+
+  std::set<int> get_happenings(const plansys2_msgs::msg::Plan & plan) const;
+  std::set<int>::iterator get_happening(int time, const std::set<int> & happenings) const;
+  std::set<int>::iterator get_previous(int time, const std::set<int> & happenings) const;
+
+  std::multimap<int, ActionStamped> get_simple_plan(const plansys2_msgs::msg::Plan & plan) const;
+
+  std::map<int, StateVec> get_states(
+    const std::set<int> & happenings,
+    const std::multimap<int, ActionStamped> & plan) const;
+  plansys2_msgs::msg::Tree from_state(
+    const std::vector<plansys2::Predicate> & preds,
+    const std::vector<plansys2::Function> & funcs) const;
+
+  std::vector<GraphNode::Ptr> get_nodes(
+    const ActionStamped & action,
+    const Graph::Ptr & graph) const;
+
+  bool is_match(
+    const GraphNode::Ptr node,
+    const ActionStamped & action) const;
+
+  std::vector<std::pair<int, ActionStamped>> get_parents(
+    const std::pair<int, ActionStamped> & action,
+    const std::multimap<int, ActionStamped> & plan,
+    const std::set<int> & happenings,
+    const std::map<int, StateVec> & states) const;
+
+  std::vector<std::pair<int, ActionStamped>> get_satisfy(
+    const std::pair<int, ActionStamped> & action,
+    const std::multimap<int, ActionStamped> & plan,
+    const std::set<int> & happenings,
+    const std::map<int, StateVec> & states) const;
+
+  std::vector<std::pair<int, ActionStamped>> get_threat(
+    const std::pair<int, ActionStamped> & action,
+    const std::multimap<int, ActionStamped> & plan,
+    const std::set<int> & happenings,
+    const std::map<int, StateVec> & states) const;
+
+  bool can_apply(
+    const std::pair<int, ActionStamped> & action,
+    const std::multimap<int, ActionStamped> & plan,
+    const int & time,
+    StateVec & state) const;
+
+  StateVec get_diff(const StateVec & X_1, const StateVec & X_2) const;
+  StateVec get_intersection(const StateVec & X_1, const StateVec & X_2) const;
+
+  plansys2_msgs::msg::Tree get_conditions(const ActionStamped & action) const;
+  plansys2_msgs::msg::Tree get_effects(const ActionStamped & action) const;
+
+  void prune_paths(GraphNode::Ptr current, GraphNode::Ptr previous) const;
+  bool check_paths(GraphNode::Ptr current, GraphNode::Ptr previous) const;
+
+  std::string get_flow(
+    const GraphNode::Ptr node,
+    const GraphNode::Ptr parent,
+    std::set<GraphNode::Ptr> & used,
+    const int & level) const;
+
+  std::string start_execution_block(
+    const GraphNode::Ptr node,
+    const GraphNode::Ptr parent,
+    const int & l) const;
+  std::string end_execution_block(
+    const GraphNode::Ptr node,
+    const GraphNode::Ptr parent,
+    const int & l) const;
+
+  void get_flow_dotgraph(
+    GraphNode::Ptr node,
+    std::set<std::string> & edges);
+  std::string get_node_dotgraph(
+    GraphNode::Ptr node,
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
+  ActionExecutor::Status get_action_status(
+    ActionStamped action,
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
+  std::string add_dot_graph_legend(
+    int level_counter,
+    int node_counter);
+  void print_graph(const plansys2::Graph::Ptr & graph) const;
+  void print_node(const GraphNode::Ptr & node, int level) const;
+
+  void replace(std::string & str, const std::string & from, const std::string & to) const;
+
+  bool is_end(
+    const std::tuple<GraphNode::Ptr, double, double> & edge,
+    const ActionStamped & action) const;
+
+  std::string t(const int & level) const;
+
+  std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
+  std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
+
+  Graph::Ptr stn_;
+  std::string bt_start_action_;
+  std::string bt_end_action_;
+  int action_time_precision_;
+};
+
+}  // namespace plansys2
+
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(plansys2::STNBTBuilder, plansys2::BTBuilder)
+
+#endif  // PLANSYS2_EXECUTOR__BT_BUILDER_PLUGINS__STN_BT_BUILDER_HPP_

--- a/plansys2_executor/launch/executor_launch.py
+++ b/plansys2_executor/launch/executor_launch.py
@@ -25,19 +25,42 @@ from launch_ros.actions import Node
 def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
-    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
+    action_bt_file = LaunchConfiguration('action_bt_file')
+    start_action_bt_file = LaunchConfiguration('start_action_bt_file')
+    end_action_bt_file = LaunchConfiguration('end_action_bt_file')
+    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
 
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
         default_value='',
         description='Namespace')
 
-    declare_default_bt_file_cmd = DeclareLaunchArgument(
-        'default_action_bt_xml_filename',
+    declare_action_bt_file_cmd = DeclareLaunchArgument(
+        'action_bt_file',
         default_value=os.path.join(
           get_package_share_directory('plansys2_executor'),
           'behavior_trees', 'plansys2_action_bt.xml'),
         description='BT representing a PDDL action')
+
+    declare_start_action_bt_file_cmd = DeclareLaunchArgument(
+        'start_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_start_action_bt.xml'),
+        description='BT representing a PDDL start action')
+
+    declare_end_action_bt_file_cmd = DeclareLaunchArgument(
+        'end_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_end_action_bt.xml'),
+        description='BT representing a PDDL end action')
+
+    declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
+        "bt_builder_plugin",
+        default_value="STNBTBuilder",
+        description="Behavior tree builder plugin.",
+    )
 
     # Specify the actions
     executor_cmd = Node(
@@ -47,9 +70,10 @@ def generate_launch_description():
         namespace=namespace,
         output='screen',
         parameters=[
-          {
-            'default_action_bt_xml_filename': default_action_bt_xml_filename
-          },
+          {'default_action_bt_xml_filename': action_bt_file},
+          {'default_start_action_bt_xml_filename': start_action_bt_file},
+          {'default_end_action_bt_xml_filename': end_action_bt_file},
+          {'bt_builder_plugin': bt_builder_plugin},
           params_file
         ])
 
@@ -57,7 +81,10 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_default_bt_file_cmd)
+    ld.add_action(declare_action_bt_file_cmd)
+    ld.add_action(declare_start_action_bt_file_cmd)
+    ld.add_action(declare_end_action_bt_file_cmd)
+    ld.add_action(declare_bt_builder_plugin_cmd)
 
     # Declare the launch options
     ld.add_action(executor_cmd)

--- a/plansys2_executor/launch/executor_launch.py
+++ b/plansys2_executor/launch/executor_launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
         "bt_builder_plugin",
-        default_value="STNBTBuilder",
+        default_value="SimpleBTBuilder",
         description="Behavior tree builder plugin.",
     )
 

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -24,6 +24,7 @@
   <depend>plansys2_domain_expert</depend>
   <depend>plansys2_problem_expert</depend>
   <depend>plansys2_planner</depend>
+  <depend>pluginlib</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>std_msgs</depend>
   <depend>libzmq3-dev</depend>
@@ -36,5 +37,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <plansys2_executor plugin="${prefix}/plugins.xml" />
   </export>
 </package>

--- a/plansys2_executor/plugins.xml
+++ b/plansys2_executor/plugins.xml
@@ -1,0 +1,10 @@
+<class_libraries>
+  <library path="bt_builder_plugins">
+    <class type="plansys2::SimpleBTBuilder" base_class_type="plansys2::BTBuilder">
+      <description></description>
+    </class>
+    <class type="plansys2::STNBTBuilder" base_class_type="plansys2::BTBuilder">
+      <description></description>
+    </class>
+  </library>
+</class_libraries>

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -399,7 +399,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   auto bt_builder_plugin = this->get_parameter("bt_builder_plugin").as_string();
   if (bt_builder_plugin.empty()) {
-    bt_builder_plugin = "STNBTBuilder";
+    bt_builder_plugin = "SimpleBTBuilder";
   }
 
   std::shared_ptr<plansys2::BTBuilder> bt_builder;

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/check_action_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/check_action_node.cpp
@@ -1,0 +1,55 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <map>
+#include <memory>
+
+#include "plansys2_executor/behavior_tree/check_action_node.hpp"
+
+namespace plansys2
+{
+
+CheckAction::CheckAction(
+  const std::string & xml_tag_name,
+  const BT::NodeConfiguration & conf)
+: ActionNodeBase(xml_tag_name, conf)
+{
+  action_map_ =
+    config().blackboard->get<std::shared_ptr<std::map<std::string, ActionExecutionInfo>>>(
+    "action_map");
+}
+
+BT::NodeStatus
+CheckAction::tick()
+{
+  std::string action;
+  getInput("action", action);
+
+  if ((*action_map_).find(action) == (*action_map_).end()) {
+    return BT::NodeStatus::RUNNING;  // Not started yet
+  }
+
+  if ((*action_map_)[action].action_executor != nullptr &&
+    (*action_map_)[action].action_executor->is_finished() &&
+    (*action_map_)[action].at_start_effects_applied &&
+    (*action_map_)[action].at_end_effects_applied)
+  {
+    return BT::NodeStatus::SUCCESS;
+  } else {
+    return BT::NodeStatus::RUNNING;
+  }
+}
+
+}  // namespace plansys2

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
@@ -1,0 +1,1276 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "plansys2_executor/bt_builder_plugins/stn_bt_builder.hpp"
+#include "plansys2_problem_expert/Utils.hpp"
+
+namespace plansys2
+{
+
+STNBTBuilder::STNBTBuilder()
+{
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+}
+
+void
+STNBTBuilder::initialize(
+  const std::string & bt_action_1,
+  const std::string & bt_action_2,
+  int precision)
+{
+  if (bt_action_1 != "") {
+    bt_start_action_ = bt_action_1;
+  } else {
+    bt_start_action_ =
+      R""""(<Sequence name="ACTION_ID">
+WAIT_PREV_ACTIONS
+  <WaitAtStartReq action="ACTION_ID"/>
+  <ApplyAtStartEffect action="ACTION_ID"/>
+</Sequence>
+)"""";
+  }
+
+  if (bt_action_2 != "") {
+    bt_end_action_ = bt_action_2;
+  } else {
+    bt_end_action_ =
+      R""""(<Sequence name="ACTION_ID">
+  <ReactiveSequence name="ACTION_ID">
+  <CheckOverAllReq action="ACTION_ID"/>
+    <ExecuteAction action="ACTION_ID"/>
+  </ReactiveSequence>
+CHECK_PREV_ACTIONS
+  <CheckAtEndReq action="ACTION_ID"/>
+  <ApplyAtEndEffect action="ACTION_ID"/>
+</Sequence>
+)"""";
+  }
+
+  action_time_precision_ = precision;
+}
+
+std::string
+STNBTBuilder::get_tree(const plansys2_msgs::msg::Plan & plan)
+{
+  stn_ = build_stn(plan);
+  auto bt = build_bt(stn_);
+  return bt;
+}
+
+std::string
+STNBTBuilder::get_dotgraph(
+  std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map,
+  bool enable_legend,
+  bool enable_print_graph)
+{
+  if (enable_print_graph) {
+    print_graph(stn_);
+  }
+
+  // create xdot graph
+  std::stringstream ss;
+  ss << "digraph plan {\n";
+
+  // dotgraph formatting options
+  ss << t(1) << "node[shape=box];\n";
+  ss << t(1) << "rankdir=TB;\n";
+
+  int max_level = 0;
+  int max_node = 0;
+
+  // Perform breadth first search
+  std::queue<std::pair<GraphNode::Ptr, int>> queue;
+  stn_->nodes.front()->visited = true;
+  queue.push(std::make_pair(stn_->nodes.front(), 0));
+
+  int prev_level = -1;
+  while (!queue.empty()) {
+    auto pair = queue.front();
+    auto node = pair.first;
+    auto level = pair.second;
+    if (level != prev_level) {
+      ss << t(1) << "subgraph cluster_" << level << " {\n";
+      auto start_time = node->action.time;
+      if (node->action.type == ActionType::END) {
+        start_time += node->action.duration;
+      }
+      ss << t(2) << "label = \"Time: " << start_time << "\";\n";
+      ss << t(2) << "style = rounded;\n";
+      ss << t(2) << "color = yellow3;\n";
+      ss << t(2) << "bgcolor = lemonchiffon;\n";
+      ss << t(2) << "labeljust = l;\n";
+      max_level = std::max(max_level, level);
+    }
+    max_node = std::max(max_node, node->node_num);
+    ss << get_node_dotgraph(node, action_map);
+    ss << t(1) << "}\n";
+    prev_level = level;
+    queue.pop();
+    for (auto arc : node->output_arcs) {
+      auto child = std::get<0>(arc);
+      if (!child->visited) {
+        child->visited = true;
+        queue.push(std::make_pair(child, level + 1));
+      }
+    }
+  }
+
+  // Reset visited flag.
+  for (auto node : stn_->nodes) {
+    node->visited = false;
+  }
+
+  // define the edges
+  std::set<std::string> edges;
+  for (const auto & graph_root : stn_->nodes) {
+    get_flow_dotgraph(graph_root, edges);
+  }
+
+  for (const auto & edge : edges) {
+    ss << t(1) << edge;
+  }
+
+  if (enable_legend) {
+    max_level++;
+    max_node++;
+    ss << add_dot_graph_legend(max_level, max_node);
+  }
+
+  ss << "}";
+
+  return ss.str();
+}
+
+Graph::Ptr
+STNBTBuilder::build_stn(const plansys2_msgs::msg::Plan & plan) const
+{
+  auto stn = init_graph(plan);
+  auto happenings = get_happenings(plan);
+  auto simple_plan = get_simple_plan(plan);
+  auto states = get_states(happenings, simple_plan);
+
+  for (const auto & item : simple_plan) {
+    // Skip the first action corresponding to the initial state
+    if (item.first < 0) {
+      continue;
+    }
+
+    // Get the graph nodes corresponding to the current action
+    auto current = get_nodes(item.second, stn);
+
+    // Get the parent actions of the current action
+    auto parents = get_parents(item, simple_plan, happenings, states);
+
+    for (const auto & parent : parents) {
+      auto previous = get_nodes(parent.second, stn);
+      for (auto & n : current) {
+        for (auto & h : previous) {
+          prune_paths(n, h);
+          if (!check_paths(n, h)) {
+            h->output_arcs.insert(std::make_tuple(n, 0, std::numeric_limits<float>::infinity()));
+            n->input_arcs.insert(std::make_tuple(h, 0, std::numeric_limits<float>::infinity()));
+          }
+        }
+      }
+    }
+  }
+
+  return stn;
+}
+
+std::string
+STNBTBuilder::build_bt(const Graph::Ptr stn) const
+{
+  std::set<GraphNode::Ptr> used;
+  const auto & root = stn->nodes.front();
+
+  auto bt = std::string("<root main_tree_to_execute=\"MainTree\">\n") + t(1) +
+    "<BehaviorTree ID=\"MainTree\">\n";
+  bt = bt + get_flow(root, root, used, 1);
+  bt = bt + t(1) + "</BehaviorTree>\n</root>\n";
+
+  return bt;
+}
+
+Graph::Ptr
+STNBTBuilder::init_graph(const plansys2_msgs::msg::Plan & plan) const
+{
+  auto graph = Graph::make_shared();
+  auto action_sequence = get_plan_actions(plan);
+
+  // Add a node to represent the initial state
+  auto predicates = problem_client_->getPredicates();
+  auto functions = problem_client_->getFunctions();
+
+  int node_cnt = 0;
+  auto init_node = GraphNode::make_shared(node_cnt++);
+  init_node->action.action = std::make_shared<plansys2_msgs::msg::DurativeAction>();
+  init_node->action.action->at_end_effects = from_state(predicates, functions);
+  init_node->action.type = ActionType::INIT;
+  graph->nodes.push_back(init_node);
+
+  // Add nodes for the start and end snap actions
+  for (const auto & action : action_sequence) {
+    auto start_node = GraphNode::make_shared(node_cnt++);
+    start_node->action = action;
+    start_node->action.type = ActionType::START;
+
+    auto end_node = GraphNode::make_shared(node_cnt++);
+    end_node->action = action;
+    end_node->action.type = ActionType::END;
+
+    start_node->output_arcs.insert(std::make_tuple(end_node, action.duration, action.duration));
+    end_node->input_arcs.insert(std::make_tuple(start_node, action.duration, action.duration));
+
+    graph->nodes.push_back(start_node);
+    graph->nodes.push_back(end_node);
+  }
+
+  // Add a node to represent the goal
+  auto goal = problem_client_->getGoal();
+  plansys2_msgs::msg::Tree * goal_tree = &goal;
+
+  auto goal_node = GraphNode::make_shared(node_cnt++);
+  goal_node->action.action = std::make_shared<plansys2_msgs::msg::DurativeAction>();
+  goal_node->action.action->at_start_requirements = *goal_tree;
+  goal_node->action.type = ActionType::GOAL;
+  graph->nodes.push_back(goal_node);
+
+  return graph;
+}
+
+std::vector<ActionStamped>
+STNBTBuilder::get_plan_actions(const plansys2_msgs::msg::Plan & plan) const
+{
+  std::vector<ActionStamped> ret;
+
+  for (auto & item : plan.items) {
+    ActionStamped action_stamped;
+    action_stamped.time = item.time;
+    action_stamped.expression = item.action;
+    action_stamped.duration = item.duration;
+    action_stamped.type = ActionType::DURATIVE;
+    action_stamped.action =
+      domain_client_->getDurativeAction(
+      get_action_name(item.action), get_action_params(item.action));
+
+    ret.push_back(action_stamped);
+  }
+
+  return ret;
+}
+
+std::set<int>
+STNBTBuilder::get_happenings(const plansys2_msgs::msg::Plan & plan) const
+{
+  std::set<int> happenings;
+  happenings.insert(-1);
+  auto action_sequence = get_plan_actions(plan);
+  for (const auto & action : action_sequence) {
+    auto time = to_int_time(action.time, action_time_precision_ + 1);
+    auto duration = to_int_time(action.duration, action_time_precision_ + 1);
+    happenings.insert(time);
+    happenings.insert(time + duration);
+  }
+  return happenings;
+}
+
+std::set<int>::iterator
+STNBTBuilder::get_happening(int time, const std::set<int> & happenings) const
+{
+  // This function returns an iterator pointing to either
+  //   1. the first element that is equal to the key or
+  //   2. the last element that is less than the key,
+  // whichever of the two is greater.
+
+  // lower_bound returns an iterator pointing to the first element that is
+  // not less than (i.e. greater or equal to) key.
+  auto it = happenings.lower_bound(time);
+  if (it != happenings.end()) {
+    if (*it != time) {
+      if (it != happenings.begin()) {
+        it--;
+      } else {
+        it = happenings.end();
+      }
+    }
+  }
+
+  return it;
+}
+
+std::set<int>::iterator
+STNBTBuilder::get_previous(int time, const std::set<int> & happenings) const
+{
+  auto it = get_happening(time, happenings);
+
+  if (it != happenings.end()) {
+    if (it != happenings.begin()) {
+      return std::prev(it);
+    }
+  }
+
+  return happenings.end();
+}
+
+std::multimap<int, ActionStamped>
+STNBTBuilder::get_simple_plan(const plansys2_msgs::msg::Plan & plan) const
+{
+  std::multimap<int, ActionStamped> simple_plan;
+  auto action_sequence = get_plan_actions(plan);
+
+  // Add an action to represent the initial state
+  auto predicates = problem_client_->getPredicates();
+  auto functions = problem_client_->getFunctions();
+
+  ActionStamped init_action;
+  init_action.action = std::make_shared<plansys2_msgs::msg::DurativeAction>();
+  init_action.action->at_end_effects = from_state(predicates, functions);
+  init_action.type = ActionType::INIT;
+  simple_plan.insert(std::make_pair(-1, init_action));
+
+  // Add the snap actions
+  for (auto action : action_sequence) {
+    auto time = to_int_time(action.time, action_time_precision_ + 1);
+    auto duration = to_int_time(action.duration, action_time_precision_ + 1);
+    action.type = ActionType::START;
+    simple_plan.insert(std::make_pair(time, action));
+    action.type = ActionType::END;
+    simple_plan.insert(std::make_pair(time + duration, action));
+  }
+
+  // Create the overall actions
+  std::vector<std::pair<int, ActionStamped>> overall_actions;
+  for (const auto & action : action_sequence) {
+    auto time = to_int_time(action.time, action_time_precision_ + 1);
+    auto duration = to_int_time(action.duration, action_time_precision_ + 1);
+
+    // Find the start action
+    auto it = simple_plan.equal_range(time);
+    auto start_action = std::find_if(
+      it.first, it.second,
+      [&](std::pair<int, ActionStamped> a) {
+        return (a.second.expression == action.expression) && (a.second.type == ActionType::START);
+      });
+
+    // Find the end action
+    it = simple_plan.equal_range(time + duration);
+    auto end_action = std::find_if(
+      it.first, it.second,
+      [&](std::pair<int, ActionStamped> a) {
+        return (a.second.expression == action.expression) && (a.second.type == ActionType::END);
+      });
+
+    // Compute the overall actions
+    int prev = time;
+    for (auto iter = start_action; iter != simple_plan.end(); ++iter) {
+      if (iter->first != prev) {
+        int time = prev + (iter->first - prev) / 2;
+        auto overall_action = std::make_pair(time, start_action->second);
+        overall_action.second.type = ActionType::OVERALL;
+        overall_actions.push_back(overall_action);
+        prev = iter->first;
+      }
+      if (iter == end_action) {
+        break;
+      }
+    }
+  }
+
+  // Add the overall actions
+  for (const auto & overall_action : overall_actions) {
+    simple_plan.insert(overall_action);
+  }
+
+  return simple_plan;
+}
+
+std::map<int, StateVec>
+STNBTBuilder::get_states(
+  const std::set<int> & happenings,
+  const std::multimap<int, ActionStamped> & plan) const
+{
+  std::map<int, StateVec> states;
+
+  StateVec state_vec;
+  state_vec.predicates = problem_client_->getPredicates();
+  state_vec.functions = problem_client_->getFunctions();
+  states.insert(std::make_pair(-1, state_vec));
+
+  for (const auto & time : happenings) {
+    auto it = plan.equal_range(time);
+    for (auto iter = it.first; iter != it.second; ++iter) {
+      if (iter->second.type == ActionType::START) {
+        apply(iter->second.action->at_start_effects, state_vec.predicates, state_vec.functions);
+      } else if (iter->second.type == ActionType::END) {
+        apply(iter->second.action->at_end_effects, state_vec.predicates, state_vec.functions);
+      }
+    }
+    states.insert(std::make_pair(time, state_vec));
+  }
+
+  return states;
+}
+
+plansys2_msgs::msg::Tree
+STNBTBuilder::from_state(
+  const std::vector<plansys2::Predicate> & preds,
+  const std::vector<plansys2::Function> & funcs) const
+{
+  plansys2_msgs::msg::Tree tree;
+  plansys2_msgs::msg::Node node;
+  node.node_type = plansys2_msgs::msg::Node::AND;
+  node.node_id = 0;
+  node.negate = false;
+  tree.nodes.push_back(node);
+
+  for (const auto & pred : preds) {
+    const plansys2_msgs::msg::Node * child = &pred;
+    tree.nodes.push_back(*child);
+    tree.nodes.back().node_id = tree.nodes.size() - 1;
+    tree.nodes[0].children.push_back(tree.nodes.size() - 1);
+  }
+
+  for (const auto & func : funcs) {
+    const plansys2_msgs::msg::Node * child = &func;
+    tree.nodes.push_back(*child);
+    tree.nodes.back().node_id = tree.nodes.size() - 1;
+    tree.nodes[0].children.push_back(tree.nodes.size() - 1);
+  }
+
+  return tree;
+}
+
+std::vector<GraphNode::Ptr>
+STNBTBuilder::get_nodes(
+  const ActionStamped & action,
+  const Graph::Ptr & graph) const
+{
+  std::vector<GraphNode::Ptr> ret;
+
+  if (action.type == ActionType::INIT) {
+    auto it = std::find_if(
+      graph->nodes.begin(), graph->nodes.end(), [&](GraphNode::Ptr node) {
+        return node->action.type == ActionType::INIT;
+      });
+    if (it != graph->nodes.end()) {
+      ret.push_back(*it);
+    } else {
+      std::cerr << "get_nodes: Could not find initial state node" << std::endl;
+    }
+    return ret;
+  }
+
+  std::vector<GraphNode::Ptr> matches;
+  std::copy_if(
+    graph->nodes.begin(), graph->nodes.end(), std::back_inserter(matches),
+    std::bind(&STNBTBuilder::is_match, this, std::placeholders::_1, action));
+
+  if (action.type == ActionType::START || action.type == ActionType::OVERALL) {
+    auto it = std::find_if(
+      matches.begin(), matches.end(), [&](GraphNode::Ptr node) {
+        return node->action.type == ActionType::START;
+      });
+    if (it != matches.end()) {
+      ret.push_back(*it);
+    } else {
+      std::cerr << "get_nodes: Could not find start node" << std::endl;
+    }
+  }
+
+  if (action.type == ActionType::END || action.type == ActionType::OVERALL) {
+    auto it = std::find_if(
+      matches.begin(), matches.end(), [&](GraphNode::Ptr node) {
+        return node->action.type == ActionType::END;
+      });
+    if (it != matches.end()) {
+      ret.push_back(*it);
+    } else {
+      std::cerr << "get_nodes: Could not find end node" << std::endl;
+    }
+  }
+
+  if (ret.empty()) {
+    std::cerr << "get_nodes: Could not find graph node" << std::endl;
+  }
+
+  return ret;
+}
+
+bool
+STNBTBuilder::is_match(
+  const GraphNode::Ptr node,
+  const ActionStamped & action) const
+{
+  auto t_1 = to_int_time(node->action.time, action_time_precision_ + 1);
+  auto t_2 = to_int_time(action.time, action_time_precision_ + 1);
+  return (t_1 == t_2) && (node->action.expression == action.expression);
+}
+
+std::vector<std::pair<int, ActionStamped>>
+STNBTBuilder::get_parents(
+  const std::pair<int, ActionStamped> & action,
+  const std::multimap<int, ActionStamped> & plan,
+  const std::set<int> & happenings,
+  const std::map<int, StateVec> & states) const
+{
+  auto parents = get_satisfy(action, plan, happenings, states);
+  auto threats = get_threat(action, plan, happenings, states);
+  parents.insert(std::end(parents), std::begin(threats), std::end(threats));
+
+  return parents;
+}
+
+std::vector<std::pair<int, ActionStamped>>
+STNBTBuilder::get_satisfy(
+  const std::pair<int, ActionStamped> & action,
+  const std::multimap<int, ActionStamped> & plan,
+  const std::set<int> & happenings,
+  const std::map<int, StateVec> & states) const
+{
+  std::vector<std::pair<int, ActionStamped>> ret;
+
+  auto H_it = get_happening(action.first, happenings);
+  if (H_it == happenings.end()) {
+    std::cerr << "get_satisfy: Happening time not found" << std::endl;
+    return ret;
+  }
+  auto t_2 = *H_it;
+
+  auto R_a = parser::pddl::getSubtrees(get_conditions(action.second));
+
+  while (t_2 >= 0) {
+    H_it = get_previous(t_2, happenings);
+    if (H_it == happenings.end()) {
+      std::cerr << "get_satisfy: Previous happening time not found" << std::endl;
+      break;
+    }
+    auto t_1 = *H_it;
+
+    auto X_it = states.find(t_1);
+    if (X_it == states.end()) {
+      std::cerr << "get_satisfy: Previous state not found" << std::endl;
+      break;
+    }
+    auto X_1 = X_it->second;
+
+    for (const auto & r : R_a) {
+      if (!check(r, X_1.predicates, X_1.functions)) {
+        auto it = plan.equal_range(t_2);
+        for (auto iter = it.first; iter != it.second; ++iter) {
+          if (iter->first == action.first) {
+            if (iter->second.expression == action.second.expression) {
+              continue;
+            }
+          }
+
+          auto E_k = get_effects(iter->second);
+
+          auto X_hat = X_1;
+          apply(E_k, X_hat.predicates, X_hat.functions);
+
+          // Check if action k satisfies action i
+          if (check(r, X_hat.predicates, X_hat.functions)) {
+            ret.push_back(*iter);
+          }
+        }
+      }
+    }
+    t_2 = t_1;
+  }
+
+  auto predicates = problem_client_->getPredicates();
+  auto functions = problem_client_->getFunctions();
+
+  for (const auto & r : R_a) {
+    if (check(r, predicates, functions)) {
+      ret.push_back(*plan.begin());
+    }
+  }
+
+  return ret;
+}
+
+std::vector<std::pair<int, ActionStamped>>
+STNBTBuilder::get_threat(
+  const std::pair<int, ActionStamped> & action,
+  const std::multimap<int, ActionStamped> & plan,
+  const std::set<int> & happenings,
+  const std::map<int, StateVec> & states) const
+{
+  std::vector<std::pair<int, ActionStamped>> ret;
+
+  auto H_it = get_happening(action.first, happenings);
+  if (H_it == happenings.end()) {
+    std::cerr << "get_threat: Happening time not found" << std::endl;
+    return ret;
+  }
+  auto t_in = *H_it;
+  auto t_2 = *H_it;
+
+  auto R_a = get_conditions(action.second);
+  auto E_a = get_effects(action.second);
+
+  while (t_2 >= 0) {
+    H_it = get_previous(t_2, happenings);
+    if (H_it == happenings.end()) {
+      std::cerr << "get_threat: Previous happening time not found" << std::endl;
+      break;
+    }
+    auto t_1 = *H_it;
+
+    auto X_it = states.find(t_1);
+    if (X_it == states.end()) {
+      std::cerr << "get_threat: Previous state not found" << std::endl;
+      break;
+    }
+    auto X_1 = X_it->second;
+
+    auto X_1_a = X_1;
+    if (can_apply(action, plan, t_2, X_1_a)) {
+      auto it = plan.end();
+      H_it = happenings.find(t_2);
+      if (std::next(H_it) != happenings.end()) {
+        it = plan.lower_bound(*std::next(H_it));
+      }
+
+      for (auto iter = plan.lower_bound(t_2); iter != it; ++iter) {
+        if (iter->first == action.first) {
+          if (iter->second.expression == action.second.expression) {
+            continue;
+          }
+        }
+
+        auto X_1_k = X_1;
+        if (!can_apply(*iter, plan, t_2, X_1_k)) {
+          std::cerr << "get_threat: Suitable intermediate state not found. ";
+          std::cerr << "However, one should exist." << std::endl;
+          continue;
+        }
+
+        auto R_k = get_conditions(iter->second);
+        auto E_k = get_effects(iter->second);
+
+        auto X_hat = X_1_k;
+        apply(E_a, X_hat.predicates, X_hat.functions);
+
+        // Check if the input action threatens action k
+        if (action.second.type != ActionType::OVERALL &&
+          !check(R_k, X_hat.predicates, X_hat.functions))
+        {
+          if (t_2 != t_in) {
+            ret.push_back(*iter);
+          } else {
+            std::cerr << "get_threat: An action should not be threatened ";
+            std::cerr << "by another action at the same happening time. ";
+            std::cerr << "Check the plan validity." << std::endl;
+          }
+          continue;
+        }
+
+        auto X_bar = X_1_a;
+        apply(E_k, X_bar.predicates, X_bar.functions);
+
+        // Check if action k threatens the input action
+        if (iter->second.type != ActionType::OVERALL &&
+          !check(R_a, X_bar.predicates, X_bar.functions))
+        {
+          if (t_2 != t_in) {
+            ret.push_back(*iter);
+          } else {
+            std::cerr << "get_threat: An action should not be threatened ";
+            std::cerr << "by another action at the same happening time. ";
+            std::cerr << "Check the plan validity." << std::endl;
+          }
+          continue;
+        }
+
+        // Check if the input action and action k modify the same effect
+        if (action.second.type != ActionType::OVERALL &&
+          iter->second.type != ActionType::OVERALL)
+        {
+          auto DX_hat = get_diff(X_1_k, X_hat);
+          auto DX_bar = get_diff(X_1_a, X_bar);
+          auto intersection = get_intersection(DX_hat, DX_bar);
+          if (intersection.predicates.size() > 0 || intersection.functions.size() > 0) {
+            if (t_2 != t_in) {
+              ret.push_back(*iter);
+            } else {
+              std::cerr << "get_threat: An action should not be threatened ";
+              std::cerr << "by another action at the same happening time. ";
+              std::cerr << "Check the plan validity." << std::endl;
+            }
+          }
+        }
+      }
+    }
+    t_2 = t_1;
+  }
+
+  return ret;
+}
+
+bool
+STNBTBuilder::can_apply(
+  const std::pair<int, ActionStamped> & action,
+  const std::multimap<int, ActionStamped> & plan,
+  const int & time,
+  StateVec & state) const
+{
+  auto X = state;
+  auto R = get_conditions(action.second);
+
+  if (check(R, X.predicates, X.functions)) {
+    return true;
+  }
+
+  int n = plan.count(time);
+  auto it = plan.lower_bound(time);
+  for (int m = 1; m <= n; ++m) {
+    std::vector<bool> v(n);
+    std::fill(v.begin(), v.begin() + m, true);
+
+    state = X;
+    do {
+      for (int i = 0; i < n; ++i) {
+        if (v[i]) {
+          auto iter = std::next(it, i);
+          if (iter->first == action.first) {
+            if (iter->second.expression == action.second.expression) {
+              continue;
+            }
+          }
+          auto E = get_effects(iter->second);
+          apply(E, state.predicates, state.functions);
+          if (check(R, state.predicates, state.functions)) {
+            return true;
+          }
+        }
+      }
+    } while (std::prev_permutation(v.begin(), v.end()));
+  }
+
+  return false;
+}
+
+StateVec
+STNBTBuilder::get_diff(
+  const StateVec & X_1,
+  const StateVec & X_2) const
+{
+  StateVec ret;
+
+  // Look for predicates in X_1 that are not in X_2
+  for (const auto & p_1 : X_1.predicates) {
+    auto it = std::find_if(
+      X_2.predicates.begin(), X_2.predicates.end(),
+      [&](plansys2::Predicate p_2) {
+        return parser::pddl::checkNodeEquality(p_1, p_2);
+      });
+    if (it == X_2.predicates.end()) {
+      ret.predicates.push_back(p_1);
+    }
+  }
+
+  // Look for predicates in X_2 that are not in X_1
+  for (const auto & p_2 : X_2.predicates) {
+    auto it = std::find_if(
+      X_1.predicates.begin(), X_1.predicates.end(),
+      [&](plansys2::Predicate p_1) {
+        return parser::pddl::checkNodeEquality(p_1, p_2);
+      });
+    if (it == X_1.predicates.end()) {
+      ret.predicates.push_back(p_2);
+    }
+  }
+
+  // Look for function changes
+  for (const auto & f_1 : X_1.functions) {
+    auto it = std::find_if(
+      X_2.functions.begin(), X_2.functions.end(),
+      [&](plansys2::Function f_2) {
+        return parser::pddl::checkNodeEquality(f_1, f_2);
+      });
+    if (it != X_2.functions.end()) {
+      if (std::abs(f_1.value - it->value) >
+        1e-5 * std::max(std::abs(f_1.value), std::abs(it->value)))
+      {
+        ret.functions.push_back(f_1);
+      }
+    }
+  }
+
+  return ret;
+}
+
+StateVec
+STNBTBuilder::get_intersection(
+  const StateVec & X_1,
+  const StateVec & X_2) const
+{
+  StateVec ret;
+
+  // Look for predicates in X_1 that are also in X_2
+  for (const auto & p_1 : X_1.predicates) {
+    auto it = std::find_if(
+      X_2.predicates.begin(), X_2.predicates.end(),
+      [&](plansys2::Predicate p_2) {
+        return parser::pddl::checkNodeEquality(p_1, p_2);
+      });
+    if (it != X_2.predicates.end()) {
+      ret.predicates.push_back(p_1);
+    }
+  }
+
+  // Look for functions in X_1 that are also in X_2
+  for (const auto & f_1 : X_1.functions) {
+    auto it = std::find_if(
+      X_2.functions.begin(), X_2.functions.end(),
+      [&](plansys2::Function f_2) {
+        return parser::pddl::checkNodeEquality(f_1, f_2);
+      });
+    if (it != X_2.functions.end()) {
+      ret.functions.push_back(f_1);
+    }
+  }
+
+  return ret;
+}
+
+plansys2_msgs::msg::Tree
+STNBTBuilder::get_conditions(const ActionStamped & action) const
+{
+  if (action.type == ActionType::START) {
+    return action.action->at_start_requirements;
+  } else if (action.type == ActionType::OVERALL) {
+    return action.action->over_all_requirements;
+  } else if (action.type == ActionType::END) {
+    return action.action->at_end_requirements;
+  }
+
+  return plansys2_msgs::msg::Tree();
+}
+
+plansys2_msgs::msg::Tree
+STNBTBuilder::get_effects(const ActionStamped & action) const
+{
+  if (action.type == ActionType::START) {
+    return action.action->at_start_effects;
+  } else if (action.type == ActionType::INIT || action.type == ActionType::END) {
+    return action.action->at_end_effects;
+  }
+
+  return plansys2_msgs::msg::Tree();
+}
+
+void
+STNBTBuilder::prune_paths(GraphNode::Ptr current, GraphNode::Ptr previous) const
+{
+  // Traverse the graph from the previous node to the root
+  for (auto & in : previous->input_arcs) {
+    prune_paths(current, std::get<0>(in));
+  }
+
+  // Don't remove the link between the start and end node
+  if (previous->action.time == current->action.time) {
+    if (previous->action.expression == current->action.expression) {
+      if (previous->action.type != ActionType::START) {
+        std::cerr << "prune_paths: Expected previous action to be of type START" << std::endl;
+      }
+      if (current->action.type != ActionType::END) {
+        std::cerr << "prune_paths: Expected current action to be of type END" << std::endl;
+      }
+      return;
+    }
+  }
+
+  auto it = previous->output_arcs.begin();
+  while (it != previous->output_arcs.end()) {
+    // Check for an output link to current
+    if (std::get<0>(*it) == current) {
+      // Find the corresponding input link
+      auto in = std::find_if(
+        current->input_arcs.begin(), current->input_arcs.end(),
+        [&](std::tuple<GraphNode::Ptr, double, double> arc) {
+          return std::get<0>(arc) == previous;
+        });
+      // Remove the output and input links
+      if (in != current->input_arcs.end()) {
+        current->input_arcs.erase(in);
+        it = previous->output_arcs.erase(it);
+      } else {
+        std::cerr << "prune_backards: Input arc could not be found" << std::endl;
+      }
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool
+STNBTBuilder::check_paths(GraphNode::Ptr current, GraphNode::Ptr previous) const
+{
+  // Traverse the graph from the current node to the root
+  for (auto & in : current->input_arcs) {
+    if (check_paths(std::get<0>(in), previous)) {
+      return true;
+    }
+  }
+
+  // Check if the current node is equal to the previous node
+  if (current == previous) {
+    return true;
+  }
+
+  return false;
+}
+
+std::string
+STNBTBuilder::get_flow(
+  const GraphNode::Ptr node,
+  const GraphNode::Ptr parent,
+  std::set<GraphNode::Ptr> & used,
+  const int & level) const
+{
+  int l = level;
+  const auto action_id = to_action_id(node->action, action_time_precision_);
+
+  if (used.find(node) != used.end()) {
+    return t(l) + "<WaitAction action=\"" + action_id + "\"/>\n";
+  }
+
+  used.insert(node);
+
+  if (node->output_arcs.size() == 0) {
+    if (node->action.type == ActionType::END) {
+      return end_execution_block(node, parent, l);
+    }
+    std::cerr << "get_flow: Unexpected action type" << std::endl;
+    return {};
+  }
+
+  std::string flow;
+
+  if (node->action.type != ActionType::INIT) {
+    flow = flow + t(l) + "<Sequence name=\"" + action_id + "\">\n";
+  }
+
+  if (node->action.type == ActionType::START) {
+    flow = flow + start_execution_block(node, parent, l + 1);
+  } else if (node->action.type == ActionType::END) {
+    flow = flow + end_execution_block(node, parent, l + 1);
+  }
+
+  int n = 0;
+  if (node->output_arcs.size() > 1) {
+    flow = flow + t(l + 1) +
+      "<Parallel success_threshold=\"" + std::to_string(node->output_arcs.size()) +
+      "\" failure_threshold=\"1\">\n";
+    n = 1;
+  }
+
+  // Visit the end action first
+  if (node->action.type == ActionType::START) {
+    auto end_action = std::find_if(
+      node->output_arcs.begin(), node->output_arcs.end(),
+      std::bind(&STNBTBuilder::is_end, this, std::placeholders::_1, node->action));
+    if (end_action != node->output_arcs.end()) {
+      const auto & next = std::get<0>(*end_action);
+      flow = flow + get_flow(next, node, used, l + n + 1);
+    }
+  }
+
+  // Visit the rest of the output arcs
+  for (const auto & child : node->output_arcs) {
+    if (!is_end(child, node->action)) {
+      const auto & next = std::get<0>(child);
+      flow = flow + get_flow(next, node, used, l + n + 1);
+    }
+  }
+
+  if (node->output_arcs.size() > 1) {
+    flow = flow + t(l + 1) + "</Parallel>\n";
+  }
+
+  if (node->action.type != ActionType::INIT) {
+    flow = flow + t(l) + "</Sequence>\n";
+  }
+
+  return flow;
+}
+
+std::string
+STNBTBuilder::start_execution_block(
+  const GraphNode::Ptr node,
+  const GraphNode::Ptr parent,
+  const int & l) const
+{
+  std::string ret;
+  std::string ret_aux = bt_start_action_;
+  const std::string action_id = to_action_id(node->action, action_time_precision_);
+
+  std::string wait_actions;
+  for (const auto & prev : node->input_arcs) {
+    const auto & prev_node = std::get<0>(prev);
+    if (prev_node != parent) {
+      wait_actions = wait_actions + t(1) + "<WaitAction action=\"" +
+        to_action_id(prev_node->action, action_time_precision_) + "\"/>";
+    }
+
+    if (prev != *node->input_arcs.rbegin()) {
+      wait_actions = wait_actions + "\n";
+    }
+  }
+
+  replace(ret_aux, "ACTION_ID", action_id);
+  replace(ret_aux, "WAIT_PREV_ACTIONS", wait_actions);
+
+  std::istringstream f(ret_aux);
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line != "") {
+      ret = ret + t(l) + line + "\n";
+    }
+  }
+  return ret;
+}
+
+std::string
+STNBTBuilder::end_execution_block(
+  const GraphNode::Ptr node,
+  const GraphNode::Ptr parent,
+  const int & l) const
+{
+  std::string ret;
+  std::string ret_aux = bt_end_action_;
+  const std::string action_id = to_action_id(node->action, action_time_precision_);
+
+  std::string check_actions;
+  for (const auto & prev : node->input_arcs) {
+    const auto & prev_node = std::get<0>(prev);
+    if (prev_node != parent) {
+      check_actions = check_actions + t(1) + "<CheckAction action=\"" +
+        to_action_id(prev_node->action, action_time_precision_) + "\"/>";
+    }
+
+    if (prev != *node->input_arcs.rbegin()) {
+      check_actions = check_actions + "\n";
+    }
+  }
+
+  replace(ret_aux, "ACTION_ID", action_id);
+  replace(ret_aux, "CHECK_PREV_ACTIONS", check_actions);
+
+  std::istringstream f(ret_aux);
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line != "") {
+      ret = ret + t(l) + line + "\n";
+    }
+  }
+  return ret;
+}
+
+void
+STNBTBuilder::get_flow_dotgraph(
+  GraphNode::Ptr node,
+  std::set<std::string> & edges)
+{
+  for (const auto & arc : node->output_arcs) {
+    auto child = std::get<0>(arc);
+    std::string edge = std::to_string(node->node_num) + "->" + std::to_string(child->node_num) +
+      ";\n";
+    edges.insert(edge);
+    get_flow_dotgraph(child, edges);
+  }
+}
+
+std::string
+STNBTBuilder::get_node_dotgraph(
+  GraphNode::Ptr node,
+  std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map)
+{
+  std::stringstream ss;
+  ss << t(2) << node->node_num << " [label=\"";
+  ss << parser::pddl::nameActionsToString(node->action.action);
+  ss << " " << to_string(node->action.type) << "\"";
+  ss << "labeljust=c,style=filled";
+
+  auto status = get_action_status(node->action, action_map);
+  switch (status) {
+    case ActionExecutor::RUNNING:
+      ss << ",color=blue,fillcolor=skyblue";
+      break;
+    case ActionExecutor::SUCCESS:
+      ss << ",color=green4,fillcolor=seagreen2";
+      break;
+    case ActionExecutor::FAILURE:
+      ss << ",color=red,fillcolor=pink";
+      break;
+    case ActionExecutor::CANCELLED:
+      ss << ",color=red,fillcolor=pink";
+      break;
+    case ActionExecutor::IDLE:
+    case ActionExecutor::DEALING:
+    default:
+      ss << ",color=yellow3,fillcolor=lightgoldenrod1";
+      break;
+  }
+  ss << "];\n";
+  return ss.str();
+}
+
+ActionExecutor::Status
+STNBTBuilder::get_action_status(
+  ActionStamped action_stamped,
+  std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map)
+{
+  auto index = "(" + parser::pddl::nameActionsToString(action_stamped.action) + "):" +
+    std::to_string(static_cast<int>(action_stamped.time * 1000));
+  if (action_map->find(index) != action_map->end()) {
+    if ((*action_map)[index].action_executor) {
+      return (*action_map)[index].action_executor->get_internal_status();
+    } else {
+      return ActionExecutor::IDLE;
+    }
+  } else {
+    return ActionExecutor::IDLE;
+  }
+}
+
+std::string
+STNBTBuilder::add_dot_graph_legend(
+  int level_counter,
+  int node_counter)
+{
+  std::stringstream ss;
+  int legend_counter = level_counter;
+  int legend_node_counter = node_counter;
+  ss << t(1);
+  ss << "subgraph cluster_" << legend_counter++ << " {\n";
+  ss << t(2);
+  ss << "label = \"Legend\";\n";
+
+  ss << t(2);
+  ss << "subgraph cluster_" << legend_counter++ << " {\n";
+  ss << t(3);
+  ss << "label = \"Plan Timestep (sec): X.X\";\n";
+  ss << t(3);
+  ss << "style = rounded;\n";
+  ss << t(3);
+  ss << "color = yellow3;\n";
+  ss << t(3);
+  ss << "bgcolor = lemonchiffon;\n";
+  ss << t(3);
+  ss << "labeljust = l;\n";
+  ss << t(3);
+  ss << legend_node_counter++ <<
+    " [label=\n\"Finished action\n\",labeljust=c,style=filled,color=green4,fillcolor=seagreen2];\n";
+  ss << t(3);
+  ss << legend_node_counter++ <<
+    " [label=\n\"Failed action\n\",labeljust=c,style=filled,color=red,fillcolor=pink];\n";
+  ss << t(3);
+  ss << legend_node_counter++ <<
+    " [label=\n\"Current action\n\",labeljust=c,style=filled,color=blue,fillcolor=skyblue];\n";
+  ss << t(3);
+  ss << legend_node_counter++ << " [label=\n\"Future action\n\",labeljust=c,style=filled," <<
+    "color=yellow3,fillcolor=lightgoldenrod1];\n";
+  ss << t(2);
+  ss << "}\n";
+
+  ss << t(2);
+  for (int i = node_counter; i < legend_node_counter; i++) {
+    if (i > node_counter) {
+      ss << "->";
+    }
+    ss << i;
+  }
+  ss << " [style=invis];\n";
+
+  ss << t(1);
+  ss << "}\n";
+
+  return ss.str();
+}
+
+void
+STNBTBuilder::print_graph(const plansys2::Graph::Ptr & graph) const
+{
+  print_node(graph->nodes.front(), 0);
+}
+
+void
+STNBTBuilder::print_node(const plansys2::GraphNode::Ptr & node, int level) const
+{
+  std::cerr << t(level) << "[" << node->action.time << "]";
+  std::cerr << " " << node->action.action->name;
+  for (const auto & param : node->action.action->parameters) {
+    std::cerr << " " << param.name;
+  }
+  std::cerr << " " << to_string(node->action.type) << std::endl;
+
+  for (const auto & arc : node->output_arcs) {
+    auto child = std::get<0>(arc);
+    print_node(child, level + 1);
+  }
+}
+
+void
+STNBTBuilder::replace(
+  std::string & str,
+  const std::string & from,
+  const std::string & to) const
+{
+  size_t start_pos = std::string::npos;
+  while ((start_pos = str.find(from)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+  }
+}
+
+bool
+STNBTBuilder::is_end(
+  const std::tuple<GraphNode::Ptr, double, double> & edge,
+  const ActionStamped & action) const
+{
+  const auto & node = std::get<0>(edge);
+  auto t_1 = to_int_time(node->action.time, action_time_precision_ + 1);
+  auto t_2 = to_int_time(action.time, action_time_precision_ + 1);
+  return action.type == ActionType::START &&
+         node->action.type == ActionType::END &&
+         (t_1 == t_2) && (node->action.expression == action.expression);
+}
+
+std::string
+STNBTBuilder::t(const int & level) const
+{
+  std::string ret;
+  for (int i = 0; i < level; i++) {
+    ret = ret + "  ";
+  }
+  return ret;
+}
+
+}  // namespace plansys2

--- a/plansys2_executor/test/test_behavior_trees/test_action_timeout_end_bt.xml
+++ b/plansys2_executor/test/test_behavior_trees/test_action_timeout_end_bt.xml
@@ -1,12 +1,10 @@
 <Sequence name="ACTION_ID">
-WAIT_PREV_ACTIONS
-  <WaitAtStartReq action="ACTION_ID"/>
-  <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
     <CheckTimeout action="ACTION_ID"/>
     <CheckOverAllReq action="ACTION_ID"/>
     <ExecuteAction action="ACTION_ID"/>
   </ReactiveSequence>
+CHECK_PREV_ACTIONS
   <CheckAtEndReq action="ACTION_ID"/>
   <ApplyAtEndEffect action="ACTION_ID"/>
 </Sequence>

--- a/plansys2_executor/test/test_behavior_trees/test_action_timeout_start_bt.xml
+++ b/plansys2_executor/test/test_behavior_trees/test_action_timeout_start_bt.xml
@@ -1,0 +1,5 @@
+<Sequence name="ACTION_ID">
+WAIT_PREV_ACTIONS
+  <WaitAtStartReq action="ACTION_ID"/>
+  <ApplyAtStartEffect action="ACTION_ID"/>
+</Sequence>

--- a/plansys2_executor/test/unit/CMakeLists.txt
+++ b/plansys2_executor/test/unit/CMakeLists.txt
@@ -1,28 +1,34 @@
 ament_add_gtest(executor_test executor_test.cpp TIMEOUT 300)
-target_compile_definitions(executor_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(executor_test
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(executor_test ${PROJECT_NAME})
 
 ament_add_gtest(action_execution_test action_execution_test.cpp)
-target_compile_definitions(action_execution_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(action_execution_test
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(action_execution_test ${PROJECT_NAME})
 
 
 ament_add_gtest(execution_tree_test execution_tree_test.cpp)
-target_compile_definitions(execution_tree_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(execution_tree_test
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(execution_tree_test ${PROJECT_NAME})
 ament_target_dependencies(execution_tree_test ${dependencies})
 
-ament_add_gtest(btbuilder_tests btbuilder_tests.cpp)
-target_compile_definitions(btbuilder_tests PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(btbuilder_tests ${PROJECT_NAME})
-ament_target_dependencies(btbuilder_tests ${dependencies})
+ament_add_gtest(simple_btbuilder_tests simple_btbuilder_tests.cpp)
+target_compile_definitions(simple_btbuilder_tests
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_link_libraries(simple_btbuilder_tests ${PROJECT_NAME} bt_builder_plugins)
+ament_target_dependencies(simple_btbuilder_tests ${dependencies})
 
 ament_add_gtest(bt_node_test bt_node_test.cpp)
-target_compile_definitions(bt_node_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(bt_node_test
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(bt_node_test ${PROJECT_NAME})
 ament_target_dependencies(bt_node_test ${dependencies})
 
 ament_add_gtest(bt_node_test_charging bt_node_test_charging.cpp)
-target_compile_definitions(bt_node_test_charging PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(bt_node_test_charging
+  PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(bt_node_test_charging ${PROJECT_NAME})
 ament_target_dependencies(bt_node_test_charging ${dependencies})

--- a/plansys2_executor/test/unit/execution_tree_test.cpp
+++ b/plansys2_executor/test/unit/execution_tree_test.cpp
@@ -30,18 +30,10 @@
 #include "plansys2_planner/PlannerClient.hpp"
 #include "plansys2_executor/BTBuilder.hpp"
 
+#include "pluginlib/class_loader.hpp"
+#include "pluginlib/class_list_macros.hpp"
+
 #include "rclcpp/rclcpp.hpp"
-
-
-class BTBuilderTest : public plansys2::BTBuilder
-{
-public:
-  explicit BTBuilderTest(
-    rclcpp::Node::SharedPtr node)
-  : BTBuilder(node)
-  {
-  }
-};
 
 
 TEST(executiotest_noden_tree, bt_builder_factory)
@@ -167,8 +159,17 @@ TEST(executiotest_noden_tree, bt_builder_factory)
   auto plan = planner_client->getPlan(domain_client->getDomain(), problem_client->getProblem());
   ASSERT_TRUE(plan);
 
-  BTBuilderTest exec_tree(test_node);
-  auto tree_str = exec_tree.get_tree(plan.value());
+  std::shared_ptr<plansys2::BTBuilder> bt_builder;
+  pluginlib::ClassLoader<plansys2::BTBuilder> bt_builder_loader("plansys2_executor",
+    "plansys2::BTBuilder");
+  try {
+    bt_builder = bt_builder_loader.createSharedInstance("plansys2::SimpleBTBuilder");
+  } catch (pluginlib::PluginlibException & ex) {
+    std::cerr << "pluginlib error: " << std::string(ex.what()) << std::endl;
+  }
+
+  bt_builder->initialize();
+  auto tree_str = bt_builder->get_tree(plan.value());
 
   std::cout << tree_str << std::endl;
   finish = true;
@@ -300,9 +301,17 @@ TEST(executiotest_noden_tree, bt_builder_factory_2)
   auto plan = planner_client->getPlan(domain_client->getDomain(), problem_client->getProblem());
   ASSERT_TRUE(plan);
 
-  BTBuilderTest exec_tree(test_node);
+  std::shared_ptr<plansys2::BTBuilder> bt_builder;
+  pluginlib::ClassLoader<plansys2::BTBuilder> bt_builder_loader("plansys2_executor",
+    "plansys2::BTBuilder");
+  try {
+    bt_builder = bt_builder_loader.createSharedInstance("plansys2::SimpleBTBuilder");
+  } catch (pluginlib::PluginlibException & ex) {
+    std::cerr << "pluginlib error: " << std::string(ex.what()) << std::endl;
+  }
 
-  auto tree_str = exec_tree.get_tree(plan.value());
+  bt_builder->initialize();
+  auto tree_str = bt_builder->get_tree(plan.value());
 
   finish = true;
   t.join();
@@ -423,9 +432,17 @@ TEST(executiotest_noden_tree, bt_builder_factory_3)
   auto plan = planner_client->getPlan(domain_client->getDomain(), problem_client->getProblem());
   ASSERT_TRUE(plan);
 
-  BTBuilderTest exec_tree(test_node);
+  std::shared_ptr<plansys2::BTBuilder> bt_builder;
+  pluginlib::ClassLoader<plansys2::BTBuilder> bt_builder_loader("plansys2_executor",
+    "plansys2::BTBuilder");
+  try {
+    bt_builder = bt_builder_loader.createSharedInstance("plansys2::SimpleBTBuilder");
+  } catch (pluginlib::PluginlibException & ex) {
+    std::cerr << "pluginlib error: " << std::string(ex.what()) << std::endl;
+  }
 
-  auto tree_str = exec_tree.get_tree(plan.value());
+  bt_builder->initialize();
+  auto tree_str = bt_builder->get_tree(plan.value());
 
   finish = true;
   t.join();

--- a/plansys2_executor/test/unit/simple_btbuilder_tests.cpp
+++ b/plansys2_executor/test/unit/simple_btbuilder_tests.cpp
@@ -27,11 +27,11 @@
 
 #include "plansys2_domain_expert/DomainExpertNode.hpp"
 #include "plansys2_domain_expert/DomainExpertClient.hpp"
+#include "plansys2_executor/bt_builder_plugins/simple_bt_builder.hpp"
 #include "plansys2_problem_expert/ProblemExpertNode.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
 #include "plansys2_planner/PlannerNode.hpp"
 #include "plansys2_planner/PlannerClient.hpp"
-#include "plansys2_executor/BTBuilder.hpp"
 #include "plansys2_problem_expert/Utils.hpp"
 
 #include "plansys2_executor/ActionExecutor.hpp"
@@ -55,20 +55,20 @@
 
 #include "gtest/gtest.h"
 
-class BTBuilderTest : public plansys2::BTBuilder
+class SimpleBTBuilderTest : public plansys2::SimpleBTBuilder
 {
 public:
-  explicit BTBuilderTest(rclcpp::Node::SharedPtr node)
-  : BTBuilder(node) {}
+  SimpleBTBuilderTest()
+  : SimpleBTBuilder() {}
 
   std::string get_tree(const plansys2_msgs::msg::Plan & current_plan)
   {
-    return BTBuilder::get_tree(current_plan);
+    return SimpleBTBuilder::get_tree(current_plan);
   }
 
   std::vector<plansys2::ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan)
   {
-    return BTBuilder::get_plan_actions(plan);
+    return SimpleBTBuilder::get_plan_actions(plan);
   }
 
   bool is_action_executable(
@@ -76,12 +76,12 @@ public:
     std::vector<plansys2::Predicate> & predicates,
     std::vector<plansys2::Function> & functions) const
   {
-    return BTBuilder::is_action_executable(action, predicates, functions);
+    return SimpleBTBuilder::is_action_executable(action, predicates, functions);
   }
 
   plansys2::Graph::Ptr get_graph(const plansys2_msgs::msg::Plan & current_plan)
   {
-    return BTBuilder::get_graph(current_plan);
+    return SimpleBTBuilder::get_graph(current_plan);
   }
 
   std::list<plansys2::GraphNode::Ptr> get_roots(
@@ -90,7 +90,7 @@ public:
     std::vector<plansys2::Function> & functions,
     int & node_counter)
   {
-    return BTBuilder::get_roots(action_sequence, predicates, functions, node_counter);
+    return SimpleBTBuilder::get_roots(action_sequence, predicates, functions, node_counter);
   }
 
   plansys2::GraphNode::Ptr get_node_satisfy(
@@ -98,7 +98,7 @@ public:
     const plansys2::Graph::Ptr & graph,
     const plansys2::GraphNode::Ptr & current)
   {
-    return BTBuilder::get_node_satisfy(requirement, graph, current);
+    return SimpleBTBuilder::get_node_satisfy(requirement, graph, current);
   }
 
   plansys2::GraphNode::Ptr get_node_satisfy(
@@ -106,24 +106,24 @@ public:
     const plansys2::GraphNode::Ptr & node,
     const plansys2::GraphNode::Ptr & current)
   {
-    return BTBuilder::get_node_satisfy(requirement, node, current);
+    return SimpleBTBuilder::get_node_satisfy(requirement, node, current);
   }
 
 
   void print_graph(const plansys2::Graph::Ptr & graph) const
   {
-    BTBuilder::print_graph(graph);
+    SimpleBTBuilder::print_graph(graph);
   }
 
   void print_graph_csv(const plansys2::Graph::Ptr & graph) const
   {
-    BTBuilder::print_graph_csv(graph);
+    SimpleBTBuilder::print_graph_csv(graph);
   }
 
   std::vector<std::tuple<uint32_t, uint32_t, uint32_t, std::string>> get_graph_tabular(
     const plansys2::Graph::Ptr & graph) const
   {
-    return BTBuilder::get_graph_tabular(graph);
+    return SimpleBTBuilder::get_graph_tabular(graph);
   }
 
   void remove_existing_requirements(
@@ -131,11 +131,11 @@ public:
     std::vector<plansys2::Predicate> & predicates,
     std::vector<plansys2::Function> & functions) const
   {
-    BTBuilder::remove_existing_requirements(requirements, predicates, functions);
+    SimpleBTBuilder::remove_existing_requirements(requirements, predicates, functions);
   }
 };
 
-TEST(btbuilder_tests, test_plan_1)
+TEST(simple_btbuilder_tests, test_plan_1)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_1");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -146,7 +146,7 @@ TEST(btbuilder_tests, test_plan_1)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 
@@ -374,7 +374,7 @@ TEST(btbuilder_tests, test_plan_1)
 }
 
 
-TEST(btbuilder_tests, test_plan_2)
+TEST(simple_btbuilder_tests, test_plan_2)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_2");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -385,7 +385,7 @@ TEST(btbuilder_tests, test_plan_2)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 
@@ -580,7 +580,7 @@ TEST(btbuilder_tests, test_plan_2)
   t.join();
 }
 
-TEST(btbuilder_tests, test_plan_3)
+TEST(simple_btbuilder_tests, test_plan_3)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_3");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -591,7 +591,7 @@ TEST(btbuilder_tests, test_plan_3)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 
@@ -671,7 +671,7 @@ TEST(btbuilder_tests, test_plan_3)
   t.join();
 }
 
-TEST(btbuilder_tests, test_plan_4)
+TEST(simple_btbuilder_tests, test_plan_4)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_4");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -682,7 +682,7 @@ TEST(btbuilder_tests, test_plan_4)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 
@@ -788,7 +788,7 @@ TEST(btbuilder_tests, test_plan_4)
   t.join();
 }
 
-TEST(btbuilder_tests, test_plan_5)
+TEST(simple_btbuilder_tests, test_plan_5)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_5");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -799,7 +799,7 @@ TEST(btbuilder_tests, test_plan_5)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 
@@ -900,7 +900,7 @@ TEST(btbuilder_tests, test_plan_5)
   t.join();
 }
 
-TEST(btbuilder_tests, test_plan_6)
+TEST(simple_btbuilder_tests, test_plan_6)
 {
   auto test_node = rclcpp::Node::make_shared("test_plan_6");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -911,7 +911,7 @@ TEST(btbuilder_tests, test_plan_6)
   auto planner_client = std::make_shared<plansys2::PlannerClient>();
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
 
-  auto btbuilder = std::make_shared<BTBuilderTest>(test_node);
+  auto btbuilder = std::make_shared<SimpleBTBuilderTest>();
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
 

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -151,7 +151,7 @@ POPFPlanSolver::is_valid_domain(
   std::string result((std::istreambuf_iterator<char>(plan_file)),
     std::istreambuf_iterator<char>());
 
-  return result.find("Solution Found") != result.npos;
+  return result.empty();
 }
 
 }  // namespace plansys2


### PR DESCRIPTION
The main changes proposed in this pull request are as follows.

1. Create a BT builder plugin interface.
2. Move the current BT builder implementation to a plugin named SimpleBTBuilder.
3. Create a new and improved STN-based BT builder plugin named STNBTBuilder.

The BT builder plugins are located in the plansys2_executor package with the header and source files placed in sub-directories labeled bt_builder_plugins. As noted above, there are two plugins available. SimpleBTBuilder is a port of the existing implementation to a plugin. STNBTBuilder is a new an improved implementation based on the notion of Simple Temporal Networks (STNs). See description below for more details.

All unit tests have been updated to use the plugin interface. However, these unit tests currently only exercise the SimpleBTBuilder plugin. Future pull requests will be created to introduce unit tests for the STNBTBuilder plugin. Nonetheless, the STNBTBuilder plugin has been tested with a handful of examples and should work with any example currently supported by PlanSys2. In addition, the new plugin more fully captures the semantics of PDDL and thus allows for the execution of more complex plans that cannot be handled by the current implementation. To allow for more vetting time, the default value for bt_builder_plugin is currently set to SimpleBTBuilder. Once we have some unit tests for STNBTBuilder and have verified that it works on more examples, the default should be set to STNBTBuilder.

**Brief Description of STNBTBuilder**

The current BT builder implementation does not capture precisely the semantics of complex time triggered plans. In some instances, this even leads to triggering actions at the wrong time. Most notably, the current implementation only allows for establishing links between the end of one durative action and the start of another. However, the PDDL standard allows for far more complex interactions. For example, the start of one durative action can trigger the start of another durative action. The STNBTBuilder plugin seeks to capture a more complete subset of the full PDDL semantics. To this end, the STNBTBuilder currently preforms 2 major steps. First, the PDDL plan is transformed into a Simple Temporal Network (STN). Second, the STN is transformed into a Behavior Tree (BT). The full details of the STN-based BT builder algorithm will be provided at a later time TBD.