### PR TITLE
Fix is_valid_domain by parsing out file

### DIFF
--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -152,18 +152,22 @@ POPFPlanSolver::is_valid_domain(
     return false;
   }
 
+  std::string line;
   std::ifstream plan_file(temp_dir.string() + "/check.out");
+  bool solution = false;
 
-  if (!plan_file) {
-    return false;
+  if (plan_file && plan_file.is_open()) {
+    while (getline(plan_file, line)) {
+      if (!solution) {
+        if (line.find("Solution Found") != std::string::npos) {
+          solution = true;
+        }
+      }
+    }
+    plan_file.close();
   }
 
-  std::string result((std::istreambuf_iterator<char>(plan_file)),
-    std::istreambuf_iterator<char>());
-
-  // Note: given the problem provided, popf is expected to produce no output
-  // given a good domain file (for some reason)
-  return result.empty();
+  return solution;
 }
 
 }  // namespace plansys2


### PR DESCRIPTION
Hi PlanSys2 devs&users,

This PR is related to #236 #232 and https://github.com/fmrico/popf/commit/bcc6cdf2d5161f8de56a5d5f1888b6848ace3821 . To check if a domain is valid, we run popf with an empty problem. After https://github.com/fmrico/popf/commit/bcc6cdf2d5161f8de56a5d5f1888b6848ace3821 , it is necessary to look for the "Solution Found" in the output"

Best



Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>