### PR TITLE
Fix regex for 'not', 'and', 'or' in parser utils

### DIFF
--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -41,14 +41,14 @@ uint8_t getNodeType(const std::string & expr, uint8_t default_node_type)
   std::smatch match;
   int first = std::numeric_limits<int>::max();
 
-  if (std::regex_search(expr, match, std::regex("\\(\\s*and"))) {
+  if (std::regex_search(expr, match, std::regex("\\(\\s*and[ (]"))) {
     if (static_cast<int>(match.position()) < first) {
       first = static_cast<int>(match.position());
       node_type = plansys2_msgs::msg::Node::AND;
     }
   }
 
-  if (std::regex_search(expr, match, std::regex("\\(\\s*or"))) {
+  if (std::regex_search(expr, match, std::regex("\\(\\s*or[ (]"))) {
     if (static_cast<int>(match.position()) < first) {
       first = static_cast<int>(match.position());
       node_type = plansys2_msgs::msg::Node::OR;

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -55,7 +55,7 @@ uint8_t getNodeType(const std::string & expr, uint8_t default_node_type)
     }
   }
 
-  if (std::regex_search(expr, match, std::regex("\\(\\s*not"))) {
+  if (std::regex_search(expr, match, std::regex("\\(\\s*not[ (]"))) {
     if (static_cast<int>(match.position()) < first) {
       first = static_cast<int>(match.position());
       node_type = plansys2_msgs::msg::Node::NOT;


### PR DESCRIPTION
This PR fixes predicates like 'notified' being detected as 'not', causing a crash. 
See this [issue](https://github.com/PlanSys2/ros2_planning_system/issues/245) for a more detailed explanation.