### PR TITLE
Standalone BT Builder Service

### DIFF
--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(plansys2_planner REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 find_package(ZMQ)
 if(ZMQ_FOUND)
@@ -47,6 +48,7 @@ set(dependencies
     pluginlib
     behaviortree_cpp_v3
     std_msgs
+    std_srvs
 )
 
 include_directories(include ${ZMQ_INCLUDE_DIRS})
@@ -56,6 +58,7 @@ set(EXECUTOR_SOURCES
   src/plansys2_executor/ActionExecutor.cpp
   src/plansys2_executor/ActionExecutorClient.cpp
   src/plansys2_executor/ExecutorNode.cpp
+  src/plansys2_executor/ComputeBT.cpp
   src/plansys2_executor/behavior_tree/execute_action_node.cpp
   src/plansys2_executor/behavior_tree/wait_action_node.cpp
   src/plansys2_executor/behavior_tree/check_action_node.cpp
@@ -78,6 +81,12 @@ add_executable(executor_node
 ament_target_dependencies(executor_node ${dependencies})
 target_link_libraries(executor_node ${PROJECT_NAME})
 
+add_executable(compute_bt
+  src/compute_bt.cpp
+)
+ament_target_dependencies(compute_bt ${dependencies})
+target_link_libraries(compute_bt ${PROJECT_NAME})
+
 install(DIRECTORY include/
   DESTINATION include/
 )
@@ -96,6 +105,7 @@ install(TARGETS
   ${PROJECT_NAME}
   bt_builder_plugins
   executor_node
+  compute_bt
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
+++ b/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
@@ -1,0 +1,87 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
+#define PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
+
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
+#include "plansys2_domain_expert/DomainExpertNode.hpp"
+#include "plansys2_executor/BTBuilder.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
+#include "plansys2_planner/PlannerClient.hpp"
+#include "plansys2_planner/PlannerNode.hpp"
+#include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include "plansys2_problem_expert/ProblemExpertNode.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include <std_srvs/srv/trigger.hpp>
+
+#include "pluginlib/class_loader.hpp"
+#include "pluginlib/class_list_macros.hpp"
+
+namespace plansys2
+{
+
+class ComputeBT : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  using CallbackReturnT =
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  ComputeBT();
+
+  CallbackReturnT on_configure(const rclcpp_lifecycle::State & state);
+  CallbackReturnT on_activate(const rclcpp_lifecycle::State & state);
+  CallbackReturnT on_deactivate(const rclcpp_lifecycle::State & state);
+  CallbackReturnT on_cleanup(const rclcpp_lifecycle::State & state);
+  CallbackReturnT on_shutdown(const rclcpp_lifecycle::State & state);
+  CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
+
+private:
+  std::string action_bt_xml_;
+  std::string start_action_bt_xml_;
+  std::string end_action_bt_xml_;
+  pluginlib::ClassLoader<plansys2::BTBuilder> bt_builder_loader_;
+
+  std::shared_ptr<plansys2::DomainExpertNode> domain_node_;
+  std::shared_ptr<plansys2::PlannerNode> planner_node_;
+  std::shared_ptr<plansys2::ProblemExpertNode> problem_node_;
+
+  std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
+  std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
+  std::shared_ptr<plansys2::PlannerClient> planner_client_;
+
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr compute_bt_srv_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr dotgraph_pub_;
+
+  void computeBTCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    const std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
+  std::string getProblem(const std::string & filename) const;
+  void savePlan(const plansys2_msgs::msg::Plan & plan, const std::string & filename) const;
+  void saveBT(const std::string & bt_xml, const std::string & filename) const;
+  void saveDotGraph(const std::string & dotgraph, const std::string & filename) const;
+};
+
+}  // namespace plansys2
+
+#endif  // PLANSYS2_EXECUTOR__COMPUTE_HPP_

--- a/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
+++ b/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
@@ -15,6 +15,11 @@
 #ifndef PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
 #define PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
 
+#include <std_srvs/srv/trigger.hpp>
+
+#include <memory>
+#include <string>
+
 #include "plansys2_domain_expert/DomainExpertClient.hpp"
 #include "plansys2_domain_expert/DomainExpertNode.hpp"
 #include "plansys2_executor/BTBuilder.hpp"
@@ -30,8 +35,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
-
-#include <std_srvs/srv/trigger.hpp>
 
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
@@ -84,4 +87,4 @@ private:
 
 }  // namespace plansys2
 
-#endif  // PLANSYS2_EXECUTOR__COMPUTE_HPP_
+#endif  // PLANSYS2_EXECUTOR__COMPUTEBT_HPP_

--- a/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
+++ b/plansys2_executor/include/plansys2_executor/ComputeBT.hpp
@@ -15,8 +15,6 @@
 #ifndef PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
 #define PLANSYS2_EXECUTOR__COMPUTEBT_HPP_
 
-#include <std_srvs/srv/trigger.hpp>
-
 #include <memory>
 #include <string>
 
@@ -31,6 +29,8 @@
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
+
+#include "std_srvs/srv/trigger.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/plansys2_executor/include/plansys2_executor/bt_builder_plugins/stn_bt_builder.hpp
+++ b/plansys2_executor/include/plansys2_executor/bt_builder_plugins/stn_bt_builder.hpp
@@ -45,14 +45,13 @@ struct GraphNode
   static Ptr make_shared(int id) {return std::make_shared<GraphNode>(id);}
 
   int node_num;
-  bool visited;
   ActionStamped action;
 
   std::set<std::tuple<GraphNode::Ptr, double, double>> input_arcs;
   std::set<std::tuple<GraphNode::Ptr, double, double>> output_arcs;
 
   explicit GraphNode(int id)
-  : node_num(id), visited(false) {}
+  : node_num(id) {}
 };
 
 struct Graph
@@ -100,7 +99,7 @@ protected:
 
   std::vector<GraphNode::Ptr> get_nodes(
     const ActionStamped & action,
-    const Graph::Ptr & graph) const;
+    const Graph::Ptr graph) const;
 
   bool is_match(
     const GraphNode::Ptr node,
@@ -166,8 +165,8 @@ protected:
   std::string add_dot_graph_legend(
     int level_counter,
     int node_counter);
-  void print_graph(const plansys2::Graph::Ptr & graph) const;
-  void print_node(const GraphNode::Ptr & node, int level) const;
+  void print_graph(const plansys2::Graph::Ptr graph) const;
+  void print_node(const GraphNode::Ptr node, int level) const;
 
   void replace(std::string & str, const std::string & from, const std::string & to) const;
 

--- a/plansys2_executor/launch/compute_bt_launch.py
+++ b/plansys2_executor/launch/compute_bt_launch.py
@@ -34,7 +34,7 @@ from launch_ros.substitutions import ExecutableInPackage
 def generate_launch_description():
     use_groot = LaunchConfiguration("use_groot")
     use_rqt_dotgraph = LaunchConfiguration("use_rqt_dotgraph")
-    
+
     namespace = LaunchConfiguration('namespace')
     action_bt_file = LaunchConfiguration('action_bt_file')
     start_action_bt_file = LaunchConfiguration('start_action_bt_file')
@@ -102,7 +102,7 @@ def generate_launch_description():
           'pddl', 'road_trip_problem.pddl'),
         description="PDDL domain file.",
     )
-    
+
     # Specify the actions
     start_groot_cmd = ExecuteProcess(
         condition=IfCondition(use_groot),
@@ -112,7 +112,7 @@ def generate_launch_description():
             "monitor",
         ],
     )
-    
+
     start_plan_viewer_cmd = Node(
         package="rqt_dotgraph",
         executable="rqt_dotgraph",
@@ -128,7 +128,7 @@ def generate_launch_description():
         ],
         arguments=["--ros-args", "--log-level", "WARN"],
     )
-    
+
     compute_bt_cmd = Node(
         package='plansys2_executor',
         executable='compute_bt',
@@ -168,7 +168,7 @@ def generate_launch_description():
 
     # Add required actions
     ld.add_action(compute_bt_cmd)
-    
+
     # Add conditioned actions
     ld.add_action(visualization_group_cmd)
 

--- a/plansys2_executor/launch/compute_bt_launch.py
+++ b/plansys2_executor/launch/compute_bt_launch.py
@@ -1,0 +1,175 @@
+# Copyright 2019 Intelligent Robotics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    GroupAction,
+)
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import (
+    Node,
+    PushRosNamespace,
+)
+from launch_ros.substitutions import ExecutableInPackage
+
+
+def generate_launch_description():
+    use_groot = LaunchConfiguration("use_groot")
+    use_rqt_dotgraph = LaunchConfiguration("use_rqt_dotgraph")
+    
+    namespace = LaunchConfiguration('namespace')
+    action_bt_file = LaunchConfiguration('action_bt_file')
+    start_action_bt_file = LaunchConfiguration('start_action_bt_file')
+    end_action_bt_file = LaunchConfiguration('end_action_bt_file')
+    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
+    domain = LaunchConfiguration("domain")
+    problem = LaunchConfiguration("problem")
+
+    declare_use_groot_cmd = DeclareLaunchArgument(
+        "use_groot",
+        default_value="False",
+        description="Whether to start groot"
+    )
+
+    declare_use_rqt_dotgraph_cmd = DeclareLaunchArgument(
+        "use_rqt_dotgraph",
+        default_value="True",
+        description="Whether to start rqt_dotgraph",
+    )
+
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='ai_planning',
+        description='Namespace')
+
+    declare_action_bt_file_cmd = DeclareLaunchArgument(
+        'action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_action_bt.xml'),
+        description='BT representing a PDDL action')
+
+    declare_start_action_bt_file_cmd = DeclareLaunchArgument(
+        'start_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_start_action_bt.xml'),
+        description='BT representing a PDDL start action')
+
+    declare_end_action_bt_file_cmd = DeclareLaunchArgument(
+        'end_action_bt_file',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_end_action_bt.xml'),
+        description='BT representing a PDDL end action')
+
+    declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
+        "bt_builder_plugin",
+        default_value="STNBTBuilder",
+        description="Behavior tree builder plugin.",
+    )
+
+    declare_domain_cmd = DeclareLaunchArgument(
+        "domain",
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'pddl', 'road_trip_domain.pddl'),
+        description="PDDL domain file.",
+    )
+
+    declare_problem_cmd = DeclareLaunchArgument(
+        "problem",
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'pddl', 'road_trip_problem.pddl'),
+        description="PDDL domain file.",
+    )
+    
+    # Specify the actions
+    start_groot_cmd = ExecuteProcess(
+        condition=IfCondition(use_groot),
+        cmd=[
+            ExecutableInPackage("Groot", "groot"),
+            "--mode",
+            "monitor",
+        ],
+    )
+    
+    start_plan_viewer_cmd = Node(
+        package="rqt_dotgraph",
+        executable="rqt_dotgraph",
+        name="plan_viewer",
+        condition=IfCondition(use_rqt_dotgraph),
+        output="screen",
+        parameters=[
+            {"title": "Plan Viewer"},
+            {"use_sim_time": False},
+        ],
+        remappings=[
+            ("dot_graph", "/ai_planning/plan_dotgraph"),
+        ],
+        arguments=["--ros-args", "--log-level", "WARN"],
+    )
+    
+    compute_bt_cmd = Node(
+        package='plansys2_executor',
+        executable='compute_bt',
+        name='compute_bt',
+        namespace=namespace,
+        output='screen',
+        parameters=[
+          {'action_bt_xml_filename': action_bt_file},
+          {'start_action_bt_xml_filename': start_action_bt_file},
+          {'end_action_bt_xml_filename': end_action_bt_file},
+          {'bt_builder_plugin': bt_builder_plugin},
+          {'domain': domain},
+          {'problem': problem},
+        ])
+
+    visualization_group_cmd = GroupAction(
+        [
+            PushRosNamespace(namespace="visualization"),
+            start_groot_cmd,
+            start_plan_viewer_cmd,
+        ]
+    )
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+
+    ld.add_action(declare_use_groot_cmd)
+    ld.add_action(declare_use_rqt_dotgraph_cmd)
+
+    ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_action_bt_file_cmd)
+    ld.add_action(declare_start_action_bt_file_cmd)
+    ld.add_action(declare_end_action_bt_file_cmd)
+    ld.add_action(declare_bt_builder_plugin_cmd)
+    ld.add_action(declare_domain_cmd)
+    ld.add_action(declare_problem_cmd)
+
+    # Add required actions
+    ld.add_action(compute_bt_cmd)
+    
+    # Add conditioned actions
+    ld.add_action(visualization_group_cmd)
+
+    return ld

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -27,6 +27,7 @@
   <depend>pluginlib</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>libzmq3-dev</depend>
 
   <exec_depend>popf</exec_depend>

--- a/plansys2_executor/src/compute_bt.cpp
+++ b/plansys2_executor/src/compute_bt.cpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "plansys2_executor/ComputeBT.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<plansys2::ComputeBT>();
+
+  node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  rclcpp::spin(node->get_node_base_interface());
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -1,0 +1,419 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include <eigen3/Eigen/Dense>
+
+#include "plansys2_executor/ComputeBT.hpp"
+
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/utils/shared_library.h"
+#include "behaviortree_cpp_v3/blackboard.h"
+
+#ifdef ZMQ_FOUND
+#include <behaviortree_cpp_v3/loggers/bt_zmq_publisher.h>
+#endif
+
+#include "plansys2_executor/behavior_tree/execute_action_node.hpp"
+#include "plansys2_executor/behavior_tree/wait_action_node.hpp"
+#include "plansys2_executor/behavior_tree/check_action_node.hpp"
+#include "plansys2_executor/behavior_tree/wait_atstart_req_node.hpp"
+#include "plansys2_executor/behavior_tree/check_overall_req_node.hpp"
+#include "plansys2_executor/behavior_tree/check_atend_req_node.hpp"
+#include "plansys2_executor/behavior_tree/check_timeout_node.hpp"
+#include "plansys2_executor/behavior_tree/apply_atstart_effect_node.hpp"
+#include "plansys2_executor/behavior_tree/apply_atend_effect_node.hpp"
+
+namespace plansys2
+{
+
+ComputeBT::ComputeBT()
+: rclcpp_lifecycle::LifecycleNode("compute_bt"),
+  bt_builder_loader_("plansys2_executor", "plansys2::BTBuilder")
+{
+  using namespace std::placeholders;
+
+  this->declare_parameter<std::string>("action_bt_xml_filename", "");
+  this->declare_parameter<std::string>("start_action_bt_xml_filename", "");
+  this->declare_parameter<std::string>("end_action_bt_xml_filename", "");
+  this->declare_parameter<std::string>("bt_builder_plugin", "");
+  this->declare_parameter<std::string>("domain", "");
+  this->declare_parameter<std::string>("problem", "");
+  this->declare_parameter<int>("action_time_precision", 3);
+  this->declare_parameter<bool>("enable_dotgraph_legend", true);
+  this->declare_parameter<bool>("print_graph", true);
+  this->declare_parameter("action_timeouts.actions", std::vector<std::string>{});
+  // Declaring individual action parameters so they can be queried on the command line
+  auto action_timeouts_actions = this->get_parameter("action_timeouts.actions").as_string_array();
+  for (auto action : action_timeouts_actions) {
+    this->declare_parameter<double>(
+      "action_timeouts." + action + ".duration_overrun_percentage",
+      0.0);
+  }
+
+#ifdef ZMQ_FOUND
+  this->declare_parameter<bool>("enable_groot_monitoring", true);
+  this->declare_parameter<int>("publisher_port", 2666);
+  this->declare_parameter<int>("server_port", 2667);
+  this->declare_parameter<int>("max_msgs_per_second", 25);
+#endif
+
+  compute_bt_srv_ = create_service<std_srvs::srv::Trigger>(
+    "compute_bt",
+    std::bind(
+      &ComputeBT::computeBTCallback,
+      this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3));
+}
+
+using CallbackReturnT =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+CallbackReturnT
+ComputeBT::on_configure(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_INFO(get_logger(), "[%s] Configuring...", get_name());
+
+  auto action_bt_xml_filename =
+    this->get_parameter("action_bt_xml_filename").as_string();
+  if (action_bt_xml_filename.empty()) {
+    action_bt_xml_filename =
+      ament_index_cpp::get_package_share_directory("plansys2_executor") +
+      "/behavior_trees/plansys2_action_bt.xml";
+  }
+
+  std::ifstream action_bt_ifs(action_bt_xml_filename);
+  if (!action_bt_ifs) {
+    RCLCPP_ERROR_STREAM(get_logger(), "Error openning [" << action_bt_xml_filename << "]");
+    return CallbackReturnT::FAILURE;
+  }
+
+  action_bt_xml_.assign(
+    std::istreambuf_iterator<char>(action_bt_ifs), std::istreambuf_iterator<char>());
+
+  auto start_action_bt_xml_filename =
+    this->get_parameter("start_action_bt_xml_filename").as_string();
+  if (start_action_bt_xml_filename.empty()) {
+    start_action_bt_xml_filename =
+      ament_index_cpp::get_package_share_directory("plansys2_executor") +
+      "/behavior_trees/plansys2_start_action_bt.xml";
+  }
+
+  std::ifstream start_action_bt_ifs(start_action_bt_xml_filename);
+  if (!start_action_bt_ifs) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "Error openning [" << start_action_bt_xml_filename << "]");
+    return CallbackReturnT::FAILURE;
+  }
+
+  start_action_bt_xml_.assign(
+    std::istreambuf_iterator<char>(start_action_bt_ifs), std::istreambuf_iterator<char>());
+
+  auto end_action_bt_xml_filename =
+    this->get_parameter("end_action_bt_xml_filename").as_string();
+  if (end_action_bt_xml_filename.empty()) {
+    end_action_bt_xml_filename =
+      ament_index_cpp::get_package_share_directory("plansys2_executor") +
+      "/behavior_trees/plansys2_end_action_bt.xml";
+  }
+
+  std::ifstream end_action_bt_ifs(end_action_bt_xml_filename);
+  if (!end_action_bt_ifs) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "Error openning [" << end_action_bt_xml_filename << "]");
+    return CallbackReturnT::FAILURE;
+  }
+
+  end_action_bt_xml_.assign(
+    std::istreambuf_iterator<char>(end_action_bt_ifs), std::istreambuf_iterator<char>());
+
+  dotgraph_pub_ = this->create_publisher<std_msgs::msg::String>("plan_dotgraph", 1);
+
+  domain_node_ = std::make_shared<plansys2::DomainExpertNode>();
+  planner_node_ = std::make_shared<plansys2::PlannerNode>();
+  problem_node_ = std::make_shared<plansys2::ProblemExpertNode>();
+
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
+  planner_client_ = std::make_shared<plansys2::PlannerClient>();
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+
+  RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+CallbackReturnT
+ComputeBT::on_activate(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_INFO(get_logger(), "[%s] Activating...", get_name());
+  dotgraph_pub_->on_activate();
+  RCLCPP_INFO(get_logger(), "[%s] Activated", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+CallbackReturnT
+ComputeBT::on_deactivate(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_INFO(get_logger(), "[%s] Deactivating...", get_name());
+  dotgraph_pub_->on_deactivate();
+  RCLCPP_INFO(get_logger(), "[%s] Deactivated", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+CallbackReturnT
+ComputeBT::on_cleanup(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_INFO(get_logger(), "[%s] Cleaning up...", get_name());
+  dotgraph_pub_.reset();
+  RCLCPP_INFO(get_logger(), "[%s] Cleaned up", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+CallbackReturnT
+ComputeBT::on_shutdown(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_INFO(get_logger(), "[%s] Shutting down...", get_name());
+  dotgraph_pub_.reset();
+  RCLCPP_INFO(get_logger(), "[%s] Shutted down", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+CallbackReturnT
+ComputeBT::on_error(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_ERROR(get_logger(), "[%s] Error transition", get_name());
+  return CallbackReturnT::SUCCESS;
+}
+
+void
+ComputeBT::computeBTCallback(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  const std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  auto domain_filename = this->get_parameter("domain").as_string();
+  const std::filesystem::path domain_path{domain_filename};
+  if (!std::filesystem::exists(domain_path)) {
+    RCLCPP_ERROR(get_logger(), "%s not found!", domain_filename.c_str());
+    return;
+  }
+
+  auto problem_filename = this->get_parameter("problem").as_string();
+  const std::filesystem::path problem_path{problem_filename};
+  if (!std::filesystem::exists(problem_path)) {
+    RCLCPP_ERROR(get_logger(), "%s not found!", problem_filename.c_str());
+    return;
+  }
+
+  auto problem_string = getProblem(problem_filename);
+
+  domain_node_->set_parameter({"model_file", domain_filename});
+  problem_node_->set_parameter({"model_file", domain_filename});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+
+  exe.add_node(domain_node_->get_node_base_interface());
+  exe.add_node(problem_node_->get_node_base_interface());
+  exe.add_node(planner_node_->get_node_base_interface());
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+
+  domain_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  domain_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  problem_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  planner_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  problem_client_->addProblem(problem_string);
+
+  auto domain = domain_client_->getDomain();
+  auto problem = problem_client_->getProblem();
+  auto plan = planner_client_->getPlan(domain, problem);
+
+  savePlan(plan.value(), problem_path.stem().u8string());
+
+  auto action_map = std::make_shared<std::map<std::string, ActionExecutionInfo>>();
+  auto action_timeout_actions = this->get_parameter("action_timeouts.actions").as_string_array();
+
+  for (const auto & plan_item : plan.value().items) {
+    auto index = BTBuilder::to_action_id(plan_item, 3);
+
+    (*action_map)[index] = ActionExecutionInfo();
+    (*action_map)[index].action_executor =
+      ActionExecutor::make_shared(plan_item.action, shared_from_this());
+    (*action_map)[index].durative_action_info =
+      domain_client_->getDurativeAction(
+      get_action_name(plan_item.action), get_action_params(plan_item.action));
+
+    (*action_map)[index].duration = plan_item.duration;
+    std::string action_name = (*action_map)[index].durative_action_info->name;
+    if (std::find(
+        action_timeout_actions.begin(), action_timeout_actions.end(),
+        action_name) != action_timeout_actions.end() &&
+      this->has_parameter("action_timeouts." + action_name + ".duration_overrun_percentage"))
+    {
+      (*action_map)[index].duration_overrun_percentage = this->get_parameter(
+        "action_timeouts." + action_name + ".duration_overrun_percentage").as_double();
+    }
+    RCLCPP_INFO(
+      get_logger(), "Action %s timeout percentage %f", action_name.c_str(),
+      (*action_map)[index].duration_overrun_percentage);
+  }
+
+  auto bt_builder_plugin = this->get_parameter("bt_builder_plugin").as_string();
+  if (bt_builder_plugin.empty()) {
+    bt_builder_plugin = "SimpleBTBuilder";
+  }
+  RCLCPP_INFO(get_logger(), "bt_builder_plugin: %s", bt_builder_plugin.c_str());
+
+  std::shared_ptr<plansys2::BTBuilder> bt_builder;
+  try {
+    bt_builder = bt_builder_loader_.createSharedInstance("plansys2::" + bt_builder_plugin);
+  } catch (pluginlib::PluginlibException & ex) {
+    RCLCPP_ERROR(get_logger(), "pluginlib error: %s", ex.what());
+  }
+
+  if (bt_builder_plugin == "SimpleBTBuilder") {
+    bt_builder->initialize(action_bt_xml_);
+  } else if (bt_builder_plugin == "STNBTBuilder") {
+    auto precision = this->get_parameter("action_time_precision").as_int();
+    bt_builder->initialize(start_action_bt_xml_, end_action_bt_xml_, precision);
+  }
+
+  auto bt_xml = bt_builder->get_tree(plan.value());
+  saveBT(bt_xml, problem_path.stem().u8string());
+
+  std_msgs::msg::String dotgraph_msg;
+  dotgraph_msg.data = bt_builder->get_dotgraph(
+    action_map, this->get_parameter("enable_dotgraph_legend").as_bool(),
+    this->get_parameter("print_graph").as_bool());
+  dotgraph_pub_->publish(dotgraph_msg);
+  saveDotGraph(dotgraph_msg.data, problem_path.stem().u8string());
+
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set("action_map", action_map);
+  blackboard->set("node", shared_from_this());
+  blackboard->set("domain_client", domain_client_);
+  blackboard->set("problem_client", problem_client_);
+
+  BT::BehaviorTreeFactory factory;
+  factory.registerNodeType<ExecuteAction>("ExecuteAction");
+  factory.registerNodeType<WaitAction>("WaitAction");
+  factory.registerNodeType<CheckAction>("CheckAction");
+  factory.registerNodeType<CheckOverAllReq>("CheckOverAllReq");
+  factory.registerNodeType<WaitAtStartReq>("WaitAtStartReq");
+  factory.registerNodeType<CheckAtEndReq>("CheckAtEndReq");
+  factory.registerNodeType<ApplyAtStartEffect>("ApplyAtStartEffect");
+  factory.registerNodeType<ApplyAtEndEffect>("ApplyAtEndEffect");
+  factory.registerNodeType<CheckTimeout>("CheckTimeout");
+
+  auto tree = factory.createTreeFromText(bt_xml, blackboard);
+
+#ifdef ZMQ_FOUND
+  unsigned int publisher_port = this->get_parameter("publisher_port").as_int();
+  unsigned int server_port = this->get_parameter("server_port").as_int();
+  unsigned int max_msgs_per_second = this->get_parameter("max_msgs_per_second").as_int();
+
+  std::unique_ptr<BT::PublisherZMQ> publisher_zmq;
+  if (this->get_parameter("enable_groot_monitoring").as_bool()) {
+    RCLCPP_DEBUG(
+      get_logger(),
+      "[%s] Groot monitoring: Publisher port: %d, Server port: %d, Max msgs per second: %d",
+      get_name(), publisher_port, server_port, max_msgs_per_second);
+    try {
+      publisher_zmq.reset(
+        new BT::PublisherZMQ(
+          tree, max_msgs_per_second, publisher_port,
+          server_port));
+    } catch (const BT::LogicError & exc) {
+      RCLCPP_ERROR(get_logger(), "ZMQ error: %s", exc.what());
+    }
+  }
+#endif
+
+  finish = true;
+  t.join();
+
+  response->success = true;
+}
+
+std::string
+ComputeBT::getProblem(const std::string & filename) const
+{
+  std::string ret;
+  std::ifstream file(filename);
+  if (file) {
+    std::ostringstream ss;
+    ss << file.rdbuf();
+    ret = ss.str();
+  }
+
+  return ret;
+}
+
+void
+ComputeBT::savePlan(const plansys2_msgs::msg::Plan & plan, const std::string & filename) const
+{
+  std::ofstream file(filename + "_plan.pddl");
+  if (file.is_open()) {
+    for (const auto & item : plan.items) {
+      file << item.time << ": " << item.action << "  [" << item.duration << "]\n";
+    }
+    file.close();
+  } else {
+    std::cerr << "Unable to open " << filename << "_plan.pddl" << std::endl;
+  }
+}
+
+void
+ComputeBT::saveBT(const std::string & bt_xml, const std::string & filename) const
+{
+  std::ofstream file(filename + "_bt.xml");
+  if (file.is_open()) {
+    file << bt_xml;
+    file.close();
+  } else {
+    std::cerr << "Unable to open " << filename << "_bt.xml" << std::endl;
+  }
+}
+
+void
+ComputeBT::saveDotGraph(const std::string & dotgraph, const std::string & filename) const
+{
+  std::ofstream file(filename + "_graph.dot");
+  if (file.is_open()) {
+    file << dotgraph << "\n";
+    file.close();
+  } else {
+    std::cerr << "Unable to open " << filename << "_graph.dot" << std::endl;
+  }
+}
+
+}  // namespace plansys2

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
 #include <filesystem>
+
+#include <chrono>
 #include <fstream>
 #include <iostream>
+#include <map>
+#include <memory>
 #include <sstream>
+#include <string>
 #include <thread>
-
-#include <eigen3/Eigen/Dense>
+#include <vector>
 
 #include "plansys2_executor/ComputeBT.hpp"
 


### PR DESCRIPTION
I have created a standalone BT builder service that takes in a domain and problem and computes an action graph and behavior tree. This is useful for testing the BT builder plugins in isolation without needing to create any action executors.

To test this ...

**Terminal 1**

    cd <pddl_directory>
    ros2 launch plansys2_executor compute_bt_launch.py domain:=domain.pddl problem:=problem.pddl

**Terminal 2**

    ros2 service call /<namespace>/compute_bt std_srvs/srv/Trigger

You should see the action graph displayed in a "Plan Viewer" window. The plan, dot graph, and BT will also be stored as files in the same directory as the problem.

**Additional Changes**

I've included a few small changes to STNBTBuilder in this PR as well. The most significant of these is a check in the build_stn function to ensure that we do not create any self-referencing edges.