### PR TITLE
Fix bt node

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -33,7 +33,7 @@ def generate_launch_description():
     action_bt_file = LaunchConfiguration('action_bt_file')
     start_action_bt_file = LaunchConfiguration('start_action_bt_file')
     end_action_bt_file = LaunchConfiguration('end_action_bt_file')
-    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
+    bt_builder_plugin = LaunchConfiguration('bt_builder_plugin')
 
     declare_model_file_cmd = DeclareLaunchArgument(
         'model_file',
@@ -71,9 +71,9 @@ def generate_launch_description():
         description='BT representing a PDDL end action')
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
-        "bt_builder_plugin",
-        default_value="SimpleBTBuilder",
-        description="Behavior tree builder plugin.",
+        'bt_builder_plugin',
+        default_value='SimpleBTBuilder',
+        description='Behavior tree builder plugin.',
     )
 
     domain_expert_cmd = IncludeLaunchDescription(

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -31,9 +31,9 @@ def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
     action_bt_file = LaunchConfiguration('action_bt_file')
-    start_action_bt_file = LaunchConfiguration("start_action_bt_file")
-    end_action_bt_file = LaunchConfiguration("end_action_bt_file")
-    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
+    start_action_bt_file = LaunchConfiguration('start_action_bt_file')
+    end_action_bt_file = LaunchConfiguration('end_action_bt_file')
+    bt_builder_plugin = LaunchConfiguration('bt_builder_plugin')
 
     declare_model_file_cmd = DeclareLaunchArgument(
         'model_file',
@@ -71,9 +71,9 @@ def generate_launch_description():
         description='BT representing a PDDL end action')
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
-        "bt_builder_plugin",
-        default_value="SimpleBTBuilder",
-        description="Behavior tree builder plugin.",
+        'bt_builder_plugin',
+        default_value='SimpleBTBuilder',
+        description='Behavior tree builder plugin.',
     )
 
     plansys2_node_cmd = Node(

--- a/plansys2_bringup/params/plansys2_params.yaml
+++ b/plansys2_bringup/params/plansys2_params.yaml
@@ -5,3 +5,7 @@ planner:
       plugin: "plansys2/POPFPlanSolver"
     TFD:
       plugin: "plansys2/TFDPlanSolver"
+executor:
+  ros__parameters:
+    bt_builder_plugin: "SimpleBTBuilder"
+    # bt_builder_plugin: "STNBTBuilder"

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -66,11 +66,8 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
     factory_.registerFromPlugin(loader.getOSName(plugin));
   }
 
-  auto options = rclcpp::NodeOptions().arguments(
-    {"--ros-args", "-r", std::string("__node:=") + get_name() + "_bb_node"});
-  auto node = rclcpp::Node::make_shared("_", options);
   blackboard_ = BT::Blackboard::create();
-  blackboard_->set("node", node);
+  blackboard_->set("node", shared_from_this());
 
   return ActionExecutorClient::on_configure(previous_state);
 }

--- a/plansys2_executor/launch/compute_bt_launch.py
+++ b/plansys2_executor/launch/compute_bt_launch.py
@@ -32,27 +32,27 @@ from launch_ros.substitutions import ExecutableInPackage
 
 
 def generate_launch_description():
-    use_groot = LaunchConfiguration("use_groot")
-    use_rqt_dotgraph = LaunchConfiguration("use_rqt_dotgraph")
+    use_groot = LaunchConfiguration('use_groot')
+    use_rqt_dotgraph = LaunchConfiguration('use_rqt_dotgraph')
 
     namespace = LaunchConfiguration('namespace')
     action_bt_file = LaunchConfiguration('action_bt_file')
     start_action_bt_file = LaunchConfiguration('start_action_bt_file')
     end_action_bt_file = LaunchConfiguration('end_action_bt_file')
-    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
-    domain = LaunchConfiguration("domain")
-    problem = LaunchConfiguration("problem")
+    bt_builder_plugin = LaunchConfiguration('bt_builder_plugin')
+    domain = LaunchConfiguration('domain')
+    problem = LaunchConfiguration('problem')
 
     declare_use_groot_cmd = DeclareLaunchArgument(
-        "use_groot",
-        default_value="False",
-        description="Whether to start groot"
+        'use_groot',
+        default_value='False',
+        description='Whether to start groot'
     )
 
     declare_use_rqt_dotgraph_cmd = DeclareLaunchArgument(
-        "use_rqt_dotgraph",
-        default_value="True",
-        description="Whether to start rqt_dotgraph",
+        'use_rqt_dotgraph',
+        default_value='True',
+        description='Whether to start rqt_dotgraph',
     )
 
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -82,51 +82,51 @@ def generate_launch_description():
         description='BT representing a PDDL end action')
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
-        "bt_builder_plugin",
-        default_value="STNBTBuilder",
-        description="Behavior tree builder plugin.",
+        'bt_builder_plugin',
+        default_value='STNBTBuilder',
+        description='Behavior tree builder plugin.',
     )
 
     declare_domain_cmd = DeclareLaunchArgument(
-        "domain",
+        'domain',
         default_value=os.path.join(
           get_package_share_directory('plansys2_executor'),
           'pddl', 'road_trip_domain.pddl'),
-        description="PDDL domain file.",
+        description='PDDL domain file.',
     )
 
     declare_problem_cmd = DeclareLaunchArgument(
-        "problem",
+        'problem',
         default_value=os.path.join(
           get_package_share_directory('plansys2_executor'),
           'pddl', 'road_trip_problem.pddl'),
-        description="PDDL domain file.",
+        description='PDDL domain file.',
     )
 
     # Specify the actions
     start_groot_cmd = ExecuteProcess(
         condition=IfCondition(use_groot),
         cmd=[
-            ExecutableInPackage("Groot", "groot"),
-            "--mode",
-            "monitor",
+            ExecutableInPackage('Groot', 'groot'),
+            '--mode',
+            'monitor',
         ],
     )
 
     start_plan_viewer_cmd = Node(
-        package="rqt_dotgraph",
-        executable="rqt_dotgraph",
-        name="plan_viewer",
+        package='rqt_dotgraph',
+        executable='rqt_dotgraph',
+        name='plan_viewer',
         condition=IfCondition(use_rqt_dotgraph),
-        output="screen",
+        output='screen',
         parameters=[
-            {"title": "Plan Viewer"},
-            {"use_sim_time": False},
+            {'title': 'Plan Viewer'},
+            {'use_sim_time': False},
         ],
         remappings=[
-            ("dot_graph", "/ai_planning/plan_dotgraph"),
+            ('dot_graph', '/ai_planning/plan_dotgraph'),
         ],
-        arguments=["--ros-args", "--log-level", "WARN"],
+        arguments=['--ros-args', '--log-level', 'WARN'],
     )
 
     compute_bt_cmd = Node(
@@ -146,7 +146,7 @@ def generate_launch_description():
 
     visualization_group_cmd = GroupAction(
         [
-            PushRosNamespace(namespace="visualization"),
+            PushRosNamespace(namespace='visualization'),
             start_groot_cmd,
             start_plan_viewer_cmd,
         ]

--- a/plansys2_executor/launch/executor_launch.py
+++ b/plansys2_executor/launch/executor_launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
     action_bt_file = LaunchConfiguration('action_bt_file')
     start_action_bt_file = LaunchConfiguration('start_action_bt_file')
     end_action_bt_file = LaunchConfiguration('end_action_bt_file')
-    bt_builder_plugin = LaunchConfiguration("bt_builder_plugin")
+    bt_builder_plugin = LaunchConfiguration('bt_builder_plugin')
 
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
@@ -57,9 +57,9 @@ def generate_launch_description():
         description='BT representing a PDDL end action')
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
-        "bt_builder_plugin",
-        default_value="SimpleBTBuilder",
-        description="Behavior tree builder plugin.",
+        'bt_builder_plugin',
+        default_value='SimpleBTBuilder',
+        description='Behavior tree builder plugin.',
     )
 
     # Specify the actions

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -554,7 +554,8 @@ ExecutorNode::get_feedback_info(
 
   for (const auto & action : *action_map) {
     if (!action.second.action_executor) {
-      RCLCPP_WARN(get_logger(), "Action executor does not exist for %s. Skipping", action.first);
+      RCLCPP_WARN(
+        get_logger(), "Action executor does not exist for %s. Skipping", action.first.c_str());
       continue;
     }
 

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -224,7 +224,7 @@ TEST(executor, action_executor_client)
   test_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
   aux_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(test_node->get_node_base_interface());
   exe.add_node(aux_node->get_node_base_interface());
@@ -313,7 +313,7 @@ TEST(executor, action_executor)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/factory.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/factory.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -640,7 +640,7 @@ TEST(executor, action_real_action_1)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -895,7 +895,7 @@ TEST(executor, cancel_bt_execution)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -1097,7 +1097,7 @@ TEST(executor, executor_client_execute_plan)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -1298,7 +1298,7 @@ TEST(executor, executor_client_ordered_sub_goals)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/domain_charging.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/domain_charging.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 9);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -1441,7 +1441,7 @@ TEST(executor, executor_client_cancel_plan)
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/factory3.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -1585,7 +1585,7 @@ TEST(executor, action_timeout)
     "action_timeouts.move.duration_overrun_percentage", 1.0);
   executor_node->set_parameter({"action_timeouts.move.duration_overrun_percentage", 1.0});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -820,25 +820,16 @@ TEST_F(TerminalTestCase, check_actors)
   auto charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("charge", 100ms);
 
   move_actor_1_node->set_parameter({"action_name", "move"});
-  move_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
-
   move_actor_2_node->set_parameter({"action_name", "move"});
-  move_actor_2_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
-
   ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
-  ask_charge_actor_1_node->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
-
   charge_actor_1_node->set_parameter({"action_name", "charge"});
-  charge_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
 
   domain_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
   problem_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
 
-  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 16, true);
-  ASSERT_GT(exe.get_number_of_threads(), 15u);
+  rclcpp::executors::SingleThreadedExecutor exe;
 
   exe.add_node(domain_node->get_node_base_interface());
   exe.add_node(problem_node->get_node_base_interface());
@@ -866,10 +857,35 @@ TEST_F(TerminalTestCase, check_actors)
   {
     rclcpp::Rate rate(10);
     auto start = test_node->now();
-    while ((test_node->now() - start).seconds() < 0.5) {
+    while ((test_node->now() - start).seconds() < 1.5) {
       rate.sleep();
     }
   }
+
+  ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    problem_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    planner_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    executor_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    move_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    move_actor_2_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    ask_charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
   domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
 
@@ -883,10 +899,36 @@ TEST_F(TerminalTestCase, check_actors)
   {
     rclcpp::Rate rate(10);
     auto start = test_node->now();
-    while ((test_node->now() - start).seconds() < 1.0) {
+    while ((test_node->now() - start).seconds() < 1.5) {
       rate.sleep();
     }
   }
+
+  ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    problem_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    planner_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    executor_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    move_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    move_actor_2_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    ask_charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
 
   auto terminal_node = std::make_shared<TerminalTest>();
   terminal_node->init();
@@ -924,12 +966,8 @@ TEST_F(TerminalTestCase, source_run_plan)
   auto charge_actor_1_node = std::make_shared<ActT>("charge");
 
   move_actor_1_node->set_parameter({"action_name", "move"});
-  move_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
   ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
-  ask_charge_actor_1_node->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
   charge_actor_1_node->set_parameter({"action_name", "charge"});
-  charge_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
 
@@ -974,6 +1012,18 @@ TEST_F(TerminalTestCase, source_run_plan)
   }
 
   ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    problem_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    planner_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    executor_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
     move_actor_1_node->get_current_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
   ASSERT_EQ(
@@ -999,6 +1049,28 @@ TEST_F(TerminalTestCase, source_run_plan)
       rate.sleep();
     }
   }
+
+  ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    problem_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    planner_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    executor_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    move_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    ask_charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    charge_actor_1_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
   auto terminal_node = std::make_shared<TerminalTest>();
   terminal_node->init();


### PR DESCRIPTION
Dear all,

Params were not correctly being readen in actions implemented with BTs because the node reading most of the user params was not the node of the action but an aux node inserted in the blackboard with another name. This PR fixes this error by inserting the BT node of the action in the blackboard.

This PR also contains some lintering in launchers and an explicit specification of the BT creator used.

Hope it helps
Francisco