### PR TITLE
Check at end reqs in bt builder

### DIFF
--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -69,6 +69,7 @@ SimpleBTBuilder::is_action_executable(
   std::vector<plansys2::Function> & functions) const
 {
   return check(action.action->at_start_requirements, predicates, functions) &&
+         check(action.action->at_end_requirements, predicates, functions) &&
          check(action.action->over_all_requirements, predicates, functions);
 }
 


### PR DESCRIPTION
Hi,

At end requirements were not checked to create the tree.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>