### PR TITLE
Remove reference to SharedPtr

### DIFF
--- a/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
+++ b/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
@@ -34,7 +34,7 @@ public:
 
   PlanSolverBase() {}
 
-  virtual void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr &, const std::string &) {}
+  virtual void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr, const std::string &) {}
 
   virtual std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,

--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -33,7 +33,7 @@ private:
 public:
   POPFPlanSolver();
 
-  void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr &, const std::string &);
+  void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr, const std::string &);
 
   std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -33,7 +33,7 @@ POPFPlanSolver::POPFPlanSolver()
 }
 
 void POPFPlanSolver::configure(
-  rclcpp_lifecycle::LifecycleNode::SharedPtr & lc_node,
+  rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node,
   const std::string & plugin_name)
 {
   parameter_name_ = plugin_name + ".arguments";


### PR DESCRIPTION
Dear devs&users,

References to shared_ptr [shouldn't be used](https://docs.ros.org/en/foxy/The-ROS2-Project/Contributing/Developer-Guide.html#c-specific), so this PR removes the only one in PlanSys2 code.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>