### PR TITLE
Add ability to specify output folder in POPF planner

### DIFF
--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -114,6 +114,7 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
     std::istreambuf_iterator<char>());
 
   auto planner = std::make_shared<plansys2::POPFPlanSolver>();
+  planner->configure(shared_from_this(), "POPF");
   domain_expert_ = std::make_shared<DomainExpert>(domain_str);
 
   bool check_valid = planner->is_valid_domain(domain_expert_->getDomain(), get_namespace());

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -108,27 +108,20 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
 
   auto model_files = tokenize(model_file, ":");
 
-  std::ifstream domain_ifs(model_files[0]);
-  std::string domain_str((
-      std::istreambuf_iterator<char>(domain_ifs)),
-    std::istreambuf_iterator<char>());
-
-  auto planner = std::make_shared<plansys2::POPFPlanSolver>();
+  auto planner = std::make_unique<plansys2::POPFPlanSolver>();
   planner->configure(shared_from_this(), "POPF");
-  domain_expert_ = std::make_shared<DomainExpert>(domain_str);
 
-  bool check_valid = planner->is_valid_domain(domain_expert_->getDomain(), get_namespace());
-  if (!check_valid) {
-    RCLCPP_ERROR_STREAM(get_logger(), "PDDL syntax error");
-    return CallbackReturnT::FAILURE;
-  }
-
-  for (size_t i = 1; i < model_files.size(); i++) {
+  for (size_t i = 0; i < model_files.size(); i++) {
     std::ifstream domain_ifs(model_files[i]);
     std::string domain_str((
         std::istreambuf_iterator<char>(domain_ifs)),
       std::istreambuf_iterator<char>());
-    domain_expert_->extendDomain(domain_str);
+
+    if (i == 0) {
+      domain_expert_ = std::make_shared<DomainExpert>(domain_str);
+    } else {
+      domain_expert_->extendDomain(domain_str);
+    }
 
     bool check_valid = planner->is_valid_domain(domain_expert_->getDomain(), get_namespace());
 

--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -27,7 +27,8 @@ namespace plansys2
 class POPFPlanSolver : public PlanSolverBase
 {
 private:
-  std::string parameter_name_;
+  std::string arguments_parameter_name_;
+  std::string output_dir_parameter_name_;
   rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node_;
 
 public:

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -60,7 +60,6 @@ POPFPlanSolver::getPlan(
   );
 
   if (node_namespace != "") {
-    std::filesystem::path tp = std::filesystem::temp_directory_path();
     for (auto p : std::filesystem::path(node_namespace) ) {
       if (p != std::filesystem::current_path().root_directory()) {
         output_dir /= p;

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -36,9 +36,14 @@ void POPFPlanSolver::configure(
   rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node,
   const std::string & plugin_name)
 {
-  parameter_name_ = plugin_name + ".arguments";
   lc_node_ = lc_node;
-  lc_node_->declare_parameter<std::string>(parameter_name_, "");
+
+  arguments_parameter_name_ = plugin_name + ".arguments";
+  lc_node_->declare_parameter<std::string>(arguments_parameter_name_, "");
+
+  output_dir_parameter_name_ = plugin_name + ".output_dir";
+  lc_node_->declare_parameter<std::string>(
+    output_dir_parameter_name_, std::filesystem::temp_directory_path());
 }
 
 std::optional<plansys2_msgs::msg::Plan>
@@ -50,37 +55,46 @@ POPFPlanSolver::getPlan(
     return {};
   }
 
+  auto output_dir = std::filesystem::path(
+    lc_node_->get_parameter(output_dir_parameter_name_).value_to_string()
+  );
+
   if (node_namespace != "") {
     std::filesystem::path tp = std::filesystem::temp_directory_path();
     for (auto p : std::filesystem::path(node_namespace) ) {
       if (p != std::filesystem::current_path().root_directory()) {
-        tp /= p;
+        output_dir /= p;
       }
     }
-    std::filesystem::create_directories(tp);
+    std::filesystem::create_directories(output_dir);
   }
+  RCLCPP_INFO(lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
 
   plansys2_msgs::msg::Plan ret;
-  std::ofstream domain_out("/tmp/" + node_namespace + "/domain.pddl");
+
+  const auto domain_file_path = output_dir / std::filesystem::path("domain.pddl");
+  std::ofstream domain_out(domain_file_path);
   domain_out << domain;
   domain_out.close();
 
-  std::ofstream problem_out("/tmp/" + node_namespace + "/problem.pddl");
+  const auto problem_file_path = output_dir / std::filesystem::path("problem.pddl");
+  std::ofstream problem_out(problem_file_path);
   problem_out << problem;
   problem_out.close();
 
-  int status = system(
-    ("ros2 run popf popf " +
-    lc_node_->get_parameter(parameter_name_).value_to_string() +
-    " /tmp/" + node_namespace + "/domain.pddl /tmp/" + node_namespace +
-    "/problem.pddl > /tmp/" + node_namespace + "/plan").c_str());
+  const auto plan_file_path = output_dir / std::filesystem::path("plan"); 
+  const auto args = lc_node_->get_parameter(arguments_parameter_name_).value_to_string();
+  const int status = system(
+    ("ros2 run popf popf " + args + " " +
+    domain_file_path.string() + " " + problem_file_path.string() + " > " + plan_file_path.string())
+    .c_str());
 
   if (status == -1) {
     return {};
   }
 
   std::string line;
-  std::ifstream plan_file("/tmp/" + node_namespace + "/plan");
+  std::ifstream plan_file(plan_file_path);
   bool solution = false;
 
   if (plan_file.is_open()) {
@@ -126,34 +140,42 @@ POPFPlanSolver::is_valid_domain(
     return false;
   }
 
-  std::filesystem::path temp_dir = std::filesystem::temp_directory_path();
+  auto output_dir = std::filesystem::path(
+    lc_node_->get_parameter(output_dir_parameter_name_).value_to_string()
+  );
+
   if (node_namespace != "") {
     for (auto p : std::filesystem::path(node_namespace) ) {
       if (p != std::filesystem::current_path().root_directory()) {
-        temp_dir /= p;
+        output_dir /= p;
       }
     }
-    std::filesystem::create_directories(temp_dir);
+    std::filesystem::create_directories(output_dir);
   }
+  RCLCPP_INFO(lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
 
-  std::ofstream domain_out(temp_dir.string() + "/check_domain.pddl");
+  const auto domain_file_path = output_dir / std::filesystem::path("check_domain.pddl");
+  std::ofstream domain_out(domain_file_path);
   domain_out << domain;
   domain_out.close();
 
-  std::ofstream problem_out(temp_dir.string() + "/check_problem.pddl");
+  const auto problem_file_path = output_dir / std::filesystem::path("check_problem.pddl");
+  std::ofstream problem_out(problem_file_path);
   problem_out << "(define (problem void) (:domain plansys2))";
   problem_out.close();
 
-  int status = system(
-    ("ros2 run popf popf " + temp_dir.string() + "/check_domain.pddl " + temp_dir.string() +
-    "/check_problem.pddl > " + temp_dir.string() + "/check.out").c_str());
+  const auto plan_file_path = output_dir / std::filesystem::path("check.out"); 
+  const int status = system(
+    ("ros2 run popf popf " +
+    domain_file_path.string() + " " + problem_file_path.string() + " > " + plan_file_path.string())
+    .c_str());
 
   if (status == -1) {
     return false;
   }
 
   std::string line;
-  std::ifstream plan_file(temp_dir.string() + "/check.out");
+  std::ifstream plan_file(plan_file_path);
   bool solution = false;
 
   if (plan_file && plan_file.is_open()) {

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -153,7 +153,9 @@ POPFPlanSolver::is_valid_domain(
     std::filesystem::create_directories(output_dir);
   }
   RCLCPP_INFO(
-    lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
+    lc_node_->get_logger(), "Writing domain validation results to %s.",
+    output_dir.string().c_str()
+  );
 
   const auto domain_file_path = output_dir / std::filesystem::path("check_domain.pddl");
   std::ofstream domain_out(domain_file_path);

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -67,7 +67,8 @@ POPFPlanSolver::getPlan(
     }
     std::filesystem::create_directories(output_dir);
   }
-  RCLCPP_INFO(lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
+  RCLCPP_INFO(
+    lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
 
   plansys2_msgs::msg::Plan ret;
 
@@ -81,7 +82,7 @@ POPFPlanSolver::getPlan(
   problem_out << problem;
   problem_out.close();
 
-  const auto plan_file_path = output_dir / std::filesystem::path("plan"); 
+  const auto plan_file_path = output_dir / std::filesystem::path("plan");
   const auto args = lc_node_->get_parameter(arguments_parameter_name_).value_to_string();
   const int status = system(
     ("ros2 run popf popf " + args + " " +
@@ -151,7 +152,8 @@ POPFPlanSolver::is_valid_domain(
     }
     std::filesystem::create_directories(output_dir);
   }
-  RCLCPP_INFO(lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
+  RCLCPP_INFO(
+    lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
 
   const auto domain_file_path = output_dir / std::filesystem::path("check_domain.pddl");
   std::ofstream domain_out(domain_file_path);
@@ -163,7 +165,7 @@ POPFPlanSolver::is_valid_domain(
   problem_out << "(define (problem void) (:domain plansys2))";
   problem_out.close();
 
-  const auto plan_file_path = output_dir / std::filesystem::path("check.out"); 
+  const auto plan_file_path = output_dir / std::filesystem::path("check.out");
   const int status = system(
     ("ros2 run popf popf " +
     domain_file_path.string() + " " + problem_file_path.string() + " > " + plan_file_path.string())


### PR DESCRIPTION
This PR allows you to specify a `<plugin_name>.output_dir` argument to specify an alternative output folder to the default temp folder `/tmp`.

We're motivated by this because we may want to specifically spit out the domain/problem PDDL files and resulting plan to another folder.

I also cleaned up a bit of the logic to better use the `std::filesystem` library and reduce duplication.