### PR TITLE
Add problem_file launch argument to problem_expert_launch.py

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -156,3 +156,4 @@ def generate_launch_description():
     ld.add_action(lifecycle_manager_cmd)
 
     return ld
+    

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -155,4 +155,4 @@ def generate_launch_description():
     ld.add_action(executor_cmd)
     ld.add_action(lifecycle_manager_cmd)
 
-    return ld    
+    return ld

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -28,6 +28,7 @@ def generate_launch_description():
 
     # Create the launch configuration variables
     model_file = LaunchConfiguration('model_file')
+    problem_file = LaunchConfiguration('problem_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
     action_bt_file = LaunchConfiguration('action_bt_file')
@@ -38,6 +39,10 @@ def generate_launch_description():
     declare_model_file_cmd = DeclareLaunchArgument(
         'model_file',
         description='PDDL Model file')
+
+    declare_problem_file_cmd = DeclareLaunchArgument(
+        'problem_file',
+        description='PDDL Problem file')
 
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
@@ -94,6 +99,7 @@ def generate_launch_description():
             'problem_expert_launch.py')),
         launch_arguments={
           'model_file': model_file,
+          'problem_file': problem_file,
           'namespace': namespace,
           'params_file': params_file
         }.items())
@@ -134,6 +140,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_problem_file_cmd)
     ld.add_action(declare_action_bt_file_cmd)
     ld.add_action(declare_start_action_bt_file_cmd)
     ld.add_action(declare_end_action_bt_file_cmd)

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -155,5 +155,4 @@ def generate_launch_description():
     ld.add_action(executor_cmd)
     ld.add_action(lifecycle_manager_cmd)
 
-    return ld
-    
+    return ld    

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -33,7 +33,7 @@ def generate_launch_description():
 
     declare_problem_file_cmd = DeclareLaunchArgument(
         'problem_file',
-        default_value="",
+        default_value='',
         description='PDDL Problem file')
 
     declare_namespace_cmd = DeclareLaunchArgument(

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -21,6 +21,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     # Create the launch configuration variables
     model_file = LaunchConfiguration('model_file')
+    problem_file = LaunchConfiguration('problem_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
 
@@ -30,28 +31,37 @@ def generate_launch_description():
         'plansys2_domain_expert/test/pddl/domain_simple.pddl',
         description='PDDL Model file')
 
+    declare_problem_file_cmd = DeclareLaunchArgument(
+        'problem_file',
+        default_value='src/ros2_planning_system/'
+        'plansys2_domain_expert/test/pddl/problem_simple_1.pddl',
+        description='PDDL Problem file')
+
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
         default_value='',
         description='Namespace')
 
     # Specify the actions
-    domain_expert_cmd = Node(
+    problem_expert_cmd = Node(
         package='plansys2_problem_expert',
         executable='problem_expert_node',
         name='problem_expert',
         namespace=namespace,
         output='screen',
-        parameters=[{'model_file': model_file}, params_file])
+        parameters=[{'model_file': model_file},
+                    {'problem_file': problem_file},
+            params_file])
 
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Set environment variables
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_problem_file_cmd)
     ld.add_action(declare_namespace_cmd)
 
     # Declare the launch options
-    ld.add_action(domain_expert_cmd)
+    ld.add_action(problem_expert_cmd)
 
     return ld

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -33,8 +33,7 @@ def generate_launch_description():
 
     declare_problem_file_cmd = DeclareLaunchArgument(
         'problem_file',
-        default_value='src/ros2_planning_system/'
-        'plansys2_domain_expert/test/pddl/problem_simple_1.pddl',
+        default_value="",
         description='PDDL Problem file')
 
     declare_namespace_cmd = DeclareLaunchArgument(

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -50,7 +50,7 @@ def generate_launch_description():
         output='screen',
         parameters=[{'model_file': model_file},
                     {'problem_file': problem_file},
-            params_file])
+                    params_file])
 
     # Create the launch description and populate
     ld = LaunchDescription()


### PR DESCRIPTION
- Add extra launch argument to `problem_expert_launch.py` named `problem_file`. 
- Changed `plansys2_bringup_launch_distributed.py` to be able to handle the new argument. 
- Renamed `domain_expert_cmd` in `problem_expert_launch.py`, possibly the result of a copy-paste action.

Now PlanSys2 can be started with domain.pddl and problem.pddl and solve the plane right away. You still need to start (or run) the plan.

NOTE: this will be a (small) breaking change.