### PR TITLE
Add option to use planner node to validate domain in domain expert

### DIFF
--- a/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
+++ b/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
@@ -34,10 +34,34 @@ public:
 
   PlanSolverBase() {}
 
-  virtual void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr, const std::string &) {}
+  /**
+   * @brief Configures the plan solver lifecycle node.
+   * @param lc_node Shared pointer to the lifecycle node.
+   * @param plugin_name The plugin name.
+   */
+  virtual void configure(
+    rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node,
+    const std::string & plugin_name) {}
 
+  /**
+   * @brief Returns a plan given a PDDL domain and problem definition.
+   * @param domain The PDDL domain as a string.
+   * @param problem The PDDL problem definition as a string.
+   * @param node_namespace The node namespace.
+   * @return An optional containing the resulting plan, if one was found.
+  */
   virtual std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
+    const std::string & node_namespace = "") = 0;
+
+  /**
+   * @brief Exposes a capability to validate a PDDL domain.
+   * @param domain The PDDL domain as a string.
+   * @param node_namespace The node namespace.
+   * @return True if the domain is valid, otherwise false.
+  */
+  virtual bool isDomainValid(
+    const std::string & domain,
     const std::string & node_namespace = "") = 0;
 };
 

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -238,6 +238,7 @@ private:
 
   rclcpp::Client<plansys2_msgs::srv::ValidateDomain>::SharedPtr
     validate_domain_client_;
+  rclcpp::Node::SharedPtr validate_domain_node_;
 
   std::unique_ptr<plansys2::POPFPlanSolver> popf_plan_solver_;
 };

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "plansys2_domain_expert/DomainExpert.hpp"
+#include "plansys2_popf_plan_solver/popf_plan_solver.hpp"
 
 #include "std_msgs/msg/string.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -31,6 +32,7 @@
 #include "plansys2_msgs/srv/get_domain.hpp"
 #include "plansys2_msgs/srv/get_node_details.hpp"
 #include "plansys2_msgs/srv/get_states.hpp"
+#include "plansys2_msgs/srv/validate_domain.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -233,6 +235,11 @@ private:
   rclcpp::Service<plansys2_msgs::srv::GetNodeDetails>::SharedPtr
     get_domain_function_details_service_;
   rclcpp::Service<plansys2_msgs::srv::GetDomain>::SharedPtr get_domain_service_;
+
+  rclcpp::Client<plansys2_msgs::srv::ValidateDomain>::SharedPtr
+    validate_domain_client_;
+
+  std::unique_ptr<plansys2::POPFPlanSolver> popf_plan_solver_;
 };
 
 }  // namespace plansys2

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -238,7 +238,7 @@ private:
 
   rclcpp::Client<plansys2_msgs::srv::ValidateDomain>::SharedPtr
     validate_domain_client_;
-  rclcpp::Node::SharedPtr validate_domain_node_;
+  rclcpp::CallbackGroup::SharedPtr validate_domain_callback_group_;
 
   std::unique_ptr<plansys2::POPFPlanSolver> popf_plan_solver_;
 };

--- a/plansys2_domain_expert/src/domain_expert_node.cpp
+++ b/plansys2_domain_expert/src/domain_expert_node.cpp
@@ -21,7 +21,11 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<plansys2::DomainExpertNode>();
-  rclcpp::spin(node->get_node_base_interface());
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+  executor.remove_node(node->get_node_base_interface());
   rclcpp::shutdown();
 
   return 0;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -112,9 +112,9 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
 
   if (validate_using_planner_node) {
     validate_domain_node_ = rclcpp::Node::make_shared("temporary_domain_validation_node");
-    validate_domain_client_ = 
+    validate_domain_client_ =
       validate_domain_node_->create_client<plansys2_msgs::srv::ValidateDomain>(
-        "planner/validate_domain");
+      "planner/validate_domain");
     while (!validate_domain_client_->wait_for_service(std::chrono::seconds(3))) {
       RCLCPP_INFO_STREAM(
         get_logger(),
@@ -144,9 +144,11 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
       request->domain = domain_expert_->getDomain();
       auto future_result = validate_domain_client_->async_send_request(std::move(request));
       if (rclcpp::spin_until_future_complete(
-        validate_domain_node_, future_result, std::chrono::seconds(1))
-        != rclcpp::FutureReturnCode::SUCCESS) {
-        RCLCPP_ERROR(get_logger(), "Timed out waiting for service: %s",
+          validate_domain_node_, future_result,
+          std::chrono::seconds(1)) != rclcpp::FutureReturnCode::SUCCESS)
+      {
+        RCLCPP_ERROR(
+          get_logger(), "Timed out waiting for service: %s",
           validate_domain_client_->get_service_name());
         return CallbackReturnT::FAILURE;
       }

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -95,7 +95,8 @@ DomainExpertNode::DomainExpertNode()
       this, std::placeholders::_1, std::placeholders::_2,
       std::placeholders::_3));
 
-  validate_domain_client_ = create_client<plansys2_msgs::srv::ValidateDomain>("planner/validate_domain");
+  validate_domain_client_ = create_client<plansys2_msgs::srv::ValidateDomain>(
+    "planner/validate_domain");
 }
 
 
@@ -107,7 +108,8 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_INFO(get_logger(), "[%s] Configuring...", get_name());
   const std::string model_file = get_parameter("model_file").get_value<std::string>();
-  const bool validate_using_planner_node = get_parameter("validate_using_planner_node").get_value<bool>();
+  const bool validate_using_planner_node = 
+    get_parameter("validate_using_planner_node").get_value<bool>();
 
   auto model_files = tokenize(model_file, ":");
 
@@ -122,7 +124,7 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
     popf_plan_solver_ = std::make_unique<plansys2::POPFPlanSolver>();
     popf_plan_solver_->configure(shared_from_this(), "POPF");
   }
-  
+
   for (size_t i = 0; i < model_files.size(); i++) {
     std::ifstream domain_ifs(model_files[i]);
     std::string domain_str((

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -43,6 +43,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/IsProblemGoalSatisfied.srv"
   "srv/RemoveProblemGoal.srv"
   "srv/ClearProblemKnowledge.srv"
+  "srv/ValidateDomain.srv"
   "action/ExecutePlan.action"
   DEPENDENCIES builtin_interfaces std_msgs action_msgs
 )

--- a/plansys2_msgs/srv/ValidateDomain.srv
+++ b/plansys2_msgs/srv/ValidateDomain.srv
@@ -1,0 +1,4 @@
+string domain
+---
+bool success
+string error_info

--- a/plansys2_planner/include/plansys2_planner/PlannerNode.hpp
+++ b/plansys2_planner/include/plansys2_planner/PlannerNode.hpp
@@ -29,6 +29,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "plansys2_msgs/srv/get_plan.hpp"
+#include "plansys2_msgs/srv/validate_domain.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -61,6 +62,11 @@ public:
     const std::shared_ptr<plansys2_msgs::srv::GetPlan::Request> request,
     const std::shared_ptr<plansys2_msgs::srv::GetPlan::Response> response);
 
+  void validate_domain_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::ValidateDomain::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::ValidateDomain::Response> response);
+
 private:
   pluginlib::ClassLoader<plansys2::PlanSolverBase> lp_loader_;
   SolverMap solvers_;
@@ -71,6 +77,8 @@ private:
 
   rclcpp::Service<plansys2_msgs::srv::GetPlan>::SharedPtr
     get_plan_service_;
+  rclcpp::Service<plansys2_msgs::srv::ValidateDomain>::SharedPtr
+    validate_domain_service_;
 };
 
 template<typename NodeT>

--- a/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
@@ -31,20 +31,6 @@ PlannerNode::PlannerNode()
   default_ids_{},
   default_types_{}
 {
-  get_plan_service_ = create_service<plansys2_msgs::srv::GetPlan>(
-    "planner/get_plan",
-    std::bind(
-      &PlannerNode::get_plan_service_callback,
-      this, std::placeholders::_1, std::placeholders::_2,
-      std::placeholders::_3));
-
-  validate_domain_service_ = create_service<plansys2_msgs::srv::ValidateDomain>(
-    "planner/validate_domain",
-    std::bind(
-      &PlannerNode::validate_domain_service_callback,
-      this, std::placeholders::_1, std::placeholders::_2,
-      std::placeholders::_3));
-
   declare_parameter("plan_solver_plugins", default_ids_);
 }
 
@@ -96,6 +82,20 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
       get_logger(), "Created default solver : %s of type %s",
       "POPF", "plansys2/POPFPlanSolver");
   }
+
+  get_plan_service_ = create_service<plansys2_msgs::srv::GetPlan>(
+    "planner/get_plan",
+    std::bind(
+      &PlannerNode::get_plan_service_callback,
+      this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3));
+
+  validate_domain_service_ = create_service<plansys2_msgs::srv::ValidateDomain>(
+    "planner/validate_domain",
+    std::bind(
+      &PlannerNode::validate_domain_service_callback,
+      this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3));
 
   RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());
   return CallbackReturnT::SUCCESS;

--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -40,7 +40,7 @@ public:
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace = "");
 
-  bool is_valid_domain(
+  bool isDomainValid(
     const std::string & domain,
     const std::string & node_namespace = "");
 };

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -132,7 +132,7 @@ POPFPlanSolver::getPlan(
 }
 
 bool
-POPFPlanSolver::is_valid_domain(
+POPFPlanSolver::isDomainValid(
   const std::string & domain,
   const std::string & node_namespace)
 {

--- a/plansys2_popf_plan_solver/test/unit/popf_test.cpp
+++ b/plansys2_popf_plan_solver/test/unit/popf_test.cpp
@@ -90,7 +90,7 @@ TEST(popf_plan_solver, check_1_ok_domain)
   auto planner = std::make_shared<plansys2::POPFPlanSolver>();
   planner->configure(node, "POPF");
 
-  bool result = planner->is_valid_domain(domain_str, "check_1_ok_domain");
+  bool result = planner->isDomainValid(domain_str, "check_1_ok_domain");
 
   ASSERT_TRUE(result);
 }
@@ -108,7 +108,7 @@ TEST(popf_plan_solver, check_2_error_domain)
   auto planner = std::make_shared<plansys2::POPFPlanSolver>();
   planner->configure(node, "POPF");
 
-  bool result = planner->is_valid_domain(domain_str, "check_2_error_domain");
+  bool result = planner->isDomainValid(domain_str, "check_2_error_domain");
 
   ASSERT_FALSE(result);
 }


### PR DESCRIPTION
This PR adds an option for the domain expert to use a planner node directly to validate the domain.

This is enabled in the domain expert through a `validate_using_planner_node` ROS parameter, which defaults to `false` to maintain compatibility. If false, a POPF instance will be created as before to validate the domain. Otherwise, a ROS service will directly call out to the planner node's planner to do the domain validation.

As such, this enforces that plan solvers now implement an `isDomainValid()` method, which is wrapped in a `planner/validate_domain` service by the `PlannerNode`.

The idea here is that if using a solver that is not POPF, we don't have to require the domain to be valid according to POPF. See e.g. this issue: https://github.com/PlanSys2/ros2_planning_system/issues/167