### PR TITLE
bt_action_node: fix groot enabling

### DIFF
--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -135,7 +135,7 @@ BTAction::on_activate(const rclcpp_lifecycle::State & previous_state)
   int server_port = get_parameter("server_port").as_int();
   unsigned int max_msgs_per_second = get_parameter("max_msgs_per_second").as_int();
 
-  if (get_parameter("enable_groot_monitoring").as_bool())
+  if (enable_groot_monitoring)
   {
     if (publisher_port <= 0 || server_port <= 0)
     {

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -130,55 +130,65 @@ BTAction::on_activate(const rclcpp_lifecycle::State & previous_state)
   }
 
 #ifdef ZMQ_FOUND
+  bool enable_groot_monitoring = get_parameter("enable_groot_monitoring").as_bool();
   int publisher_port = get_parameter("publisher_port").as_int();
   int server_port = get_parameter("server_port").as_int();
   unsigned int max_msgs_per_second = get_parameter("max_msgs_per_second").as_int();
 
-  if (publisher_port <= 0 || server_port <= 0) {
-    RCLCPP_WARN(
-      get_logger(),
-      "[%s] Groot monitoring ports not provided, disabling Groot monitoring."
-      " publisher port: %d, server port: %d",
-      get_name(), publisher_port, server_port);
-  } else if (get_parameter("enable_groot_monitoring").as_bool()) {
-    RCLCPP_DEBUG(
-      get_logger(),
-      "[%s] Groot monitoring: Publisher port: %d, Server port: %d, Max msgs per second: %d",
-      get_name(), publisher_port, server_port, max_msgs_per_second);
-    try {
-      publisher_zmq_.reset(
-        new BT::PublisherZMQ(
-          tree_, max_msgs_per_second, publisher_port,
-          server_port));
-    } catch (const BT::LogicError & exc) {
-      RCLCPP_ERROR(get_logger(), "ZMQ error: %s", exc.what());
+  if (get_parameter("enable_groot_monitoring").as_bool())
+  {
+    if (publisher_port <= 0 || server_port <= 0)
+    {
+      RCLCPP_WARN(
+          get_logger(),
+          "[%s] Groot monitoring ports not provided, disabling Groot monitoring."
+          " publisher port: %d, server port: %d",
+          get_name(), publisher_port, server_port);
+    } else {
+      RCLCPP_DEBUG(
+          get_logger(),
+          "[%s] Groot monitoring: Publisher port: %d, Server port: %d, Max msgs per second: %d",
+          get_name(), publisher_port, server_port, max_msgs_per_second);
+      try
+      {
+        publisher_zmq_.reset(
+            new BT::PublisherZMQ(
+                tree_, max_msgs_per_second, publisher_port,
+                server_port));
+      }
+      catch (const BT::LogicError &exc)
+      {
+        RCLCPP_ERROR(get_logger(), "ZMQ error: %s", exc.what());
+      }
     }
   }
 #endif
 
-  finished_ = false;
-  return ActionExecutorClient::on_activate(previous_state);
-}
+    finished_ = false;
+    return ActionExecutorClient::on_activate(previous_state);
+  }
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-BTAction::on_deactivate(const rclcpp_lifecycle::State & previous_state)
-{
-  publisher_zmq_.reset();
-  bt_minitrace_logger_.reset();
-  bt_file_logger_.reset();
-  tree_.haltTree();
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  BTAction::on_deactivate(const rclcpp_lifecycle::State &previous_state)
+  {
+    publisher_zmq_.reset();
+    bt_minitrace_logger_.reset();
+    bt_file_logger_.reset();
+    tree_.haltTree();
 
-  return ActionExecutorClient::on_deactivate(previous_state);
-}
+    return ActionExecutorClient::on_deactivate(previous_state);
+  }
 
-void
-BTAction::do_work()
-{
-  if (!finished_) {
-    BT::NodeStatus result;
-    try {
-      result = tree_.rootNode()->executeTick();
-    } catch (BT::LogicError e) {
+  void
+  BTAction::do_work()
+  {
+    if (!finished_)
+    {
+      BT::NodeStatus result;
+      try
+      {
+        result = tree_.rootNode()->executeTick();
+      } catch (BT::LogicError e) {
       RCLCPP_ERROR_STREAM(get_logger(), e.what());
       finish(false, 0.0, "BTAction behavior tree threw a BT::LogicError");
     } catch (BT::RuntimeError e) {


### PR DESCRIPTION
This change makes it possible to disable groot monitoring for `bt_action_node` at launch. Example:

```python
recharge_1_cmd = Node(
        package='plansys2_bt_actions',
        executable='bt_action_node',
        name='recharge_1',
        namespace=namespace,
        output='screen',
        parameters=[
          example_dir + '/config/params.yaml',
          {
            'action_name': 'recharge',
            'enable_groot_monitoring': False,
            'bt_xml_file': example_dir + '/behavior_trees_xml/recharge.xml'
          }
        ])
```

When `enable_groot_monitoring` is set to `false`, you now will not get the warning: `Groot monitoring ports not provided, disabling Groot monitoring. publisher port: -1, server port: -1`.

I checked with make test. Result:
```text
Running tests...
Test project /home/sentinel/dev_ws/src/ros2_planning_system/plansys2_bt_actions
    Start 1: copyright
1/7 Test #1: copyright ........................***Failed    0.34 sec
    Start 2: cppcheck
2/7 Test #2: cppcheck .........................   Passed    0.32 sec
    Start 3: cpplint
3/7 Test #3: cpplint ..........................***Failed    0.46 sec
    Start 4: lint_cmake
4/7 Test #4: lint_cmake .......................***Failed    0.12 sec
    Start 5: uncrustify
5/7 Test #5: uncrustify .......................***Failed    0.18 sec
    Start 6: xmllint
6/7 Test #6: xmllint ..........................   Passed    0.95 sec
    Start 7: bt_action_test
7/7 Test #7: bt_action_test ...................   Passed   12.56 sec

43% tests passed, 4 tests failed out of 7

Label Time Summary:
copyright     =   0.34 sec*proc (1 test)
cppcheck      =   0.32 sec*proc (1 test)
cpplint       =   0.46 sec*proc (1 test)
gtest         =  12.56 sec*proc (1 test)
lint_cmake    =   0.12 sec*proc (1 test)
linter        =   2.36 sec*proc (6 tests)
uncrustify    =   0.18 sec*proc (1 test)
xmllint       =   0.95 sec*proc (1 test)

Total Test time (real) =  14.93 sec

The following tests FAILED:
	  1 - copyright (Failed)
	  3 - cpplint (Failed)
	  4 - lint_cmake (Failed)
	  5 - uncrustify (Failed)
```

NOTE: these errors also occur when running `make test` in `plansys2_core`. So this must be caused by something else.