### PR TITLE
Remove commented-out line in domain expert node

### DIFF
--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -113,7 +113,6 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
   auto model_files = tokenize(model_file, ":");
 
   if (validate_using_planner_node) {
-    // validate_domain_node_ = rclcpp::Node::make_shared("temporary_domain_validation_node");
     validate_domain_client_ = create_client<plansys2_msgs::srv::ValidateDomain>(
       "planner/validate_domain", rmw_qos_profile_services_default, validate_domain_callback_group_);
     while (!validate_domain_client_->wait_for_service(std::chrono::seconds(3))) {


### PR DESCRIPTION
I missed deleting a commented-out line in https://github.com/PlanSys2/ros2_planning_system/pull/275 that I meant to address after I got review comments... but there were none!