### PR TITLE
Use separate problem pddl for problem expert.

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -28,6 +28,7 @@ def generate_launch_description():
 
     # Create the launch configuration variables
     model_file = LaunchConfiguration('model_file')
+    problem_file = LaunchConfiguration('problem_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
     action_bt_file = LaunchConfiguration('action_bt_file')
@@ -39,6 +40,10 @@ def generate_launch_description():
         'model_file',
         description='PDDL Model file')
 
+    declare_problem_file_cmd = DeclareLaunchArgument(
+        'problem_file',
+        description='PDDL Problem file')
+
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
         default_value='',
@@ -46,28 +51,29 @@ def generate_launch_description():
 
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
-        default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
+        default_value=os.path.join(
+            bringup_dir, 'params', 'plansys2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
     declare_action_bt_file_cmd = DeclareLaunchArgument(
         'action_bt_file',
         default_value=os.path.join(
-          get_package_share_directory('plansys2_executor'),
-          'behavior_trees', 'plansys2_action_bt.xml'),
+            get_package_share_directory('plansys2_executor'),
+            'behavior_trees', 'plansys2_action_bt.xml'),
         description='BT representing a PDDL action')
 
     declare_start_action_bt_file_cmd = DeclareLaunchArgument(
         'start_action_bt_file',
         default_value=os.path.join(
-          get_package_share_directory('plansys2_executor'),
-          'behavior_trees', 'plansys2_start_action_bt.xml'),
+            get_package_share_directory('plansys2_executor'),
+            'behavior_trees', 'plansys2_start_action_bt.xml'),
         description='BT representing a PDDL start action')
 
     declare_end_action_bt_file_cmd = DeclareLaunchArgument(
         'end_action_bt_file',
         default_value=os.path.join(
-          get_package_share_directory('plansys2_executor'),
-          'behavior_trees', 'plansys2_end_action_bt.xml'),
+            get_package_share_directory('plansys2_executor'),
+            'behavior_trees', 'plansys2_end_action_bt.xml'),
         description='BT representing a PDDL end action')
 
     declare_bt_builder_plugin_cmd = DeclareLaunchArgument(
@@ -82,9 +88,9 @@ def generate_launch_description():
             'launch',
             'domain_expert_launch.py')),
         launch_arguments={
-          'model_file': model_file,
-          'namespace': namespace,
-          'params_file': params_file
+            'model_file': model_file,
+            'namespace': namespace,
+            'params_file': params_file
         }.items())
 
     problem_expert_cmd = IncludeLaunchDescription(
@@ -93,9 +99,10 @@ def generate_launch_description():
             'launch',
             'problem_expert_launch.py')),
         launch_arguments={
-          'model_file': model_file,
-          'namespace': namespace,
-          'params_file': params_file
+            'model_file': model_file,
+            'problem_file': problem_file,
+            'namespace': namespace,
+            'params_file': params_file
         }.items())
 
     planner_cmd = IncludeLaunchDescription(
@@ -104,8 +111,8 @@ def generate_launch_description():
             'launch',
             'planner_launch.py')),
         launch_arguments={
-          'namespace': namespace,
-          'params_file': params_file
+            'namespace': namespace,
+            'params_file': params_file
         }.items())
 
     executor_cmd = IncludeLaunchDescription(
@@ -114,12 +121,12 @@ def generate_launch_description():
             'launch',
             'executor_launch.py')),
         launch_arguments={
-          'namespace': namespace,
-          'params_file': params_file,
-          'default_action_bt_xml_filename': action_bt_file,
-          'default_start_action_bt_xml_filename': start_action_bt_file,
-          'default_end_action_bt_xml_filename': end_action_bt_file,
-          'bt_builder_plugin': bt_builder_plugin,
+            'namespace': namespace,
+            'params_file': params_file,
+            'default_action_bt_xml_filename': action_bt_file,
+            'default_start_action_bt_xml_filename': start_action_bt_file,
+            'default_end_action_bt_xml_filename': end_action_bt_file,
+            'bt_builder_plugin': bt_builder_plugin,
         }.items())
 
     lifecycle_manager_cmd = Node(
@@ -134,6 +141,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_problem_file_cmd)
     ld.add_action(declare_action_bt_file_cmd)
     ld.add_action(declare_start_action_bt_file_cmd)
     ld.add_action(declare_end_action_bt_file_cmd)

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -21,6 +21,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     # Create the launch configuration variables
     model_file = LaunchConfiguration('model_file')
+    problem_file = LaunchConfiguration('problem_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
 
@@ -30,28 +31,34 @@ def generate_launch_description():
         'plansys2_domain_expert/test/pddl/domain_simple.pddl',
         description='PDDL Model file')
 
+    declare_problem_file_cmd = DeclareLaunchArgument(
+        'problem_file',
+        default_value='',
+        description='PDDL Problem file')
+
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
         default_value='',
         description='Namespace')
 
     # Specify the actions
-    domain_expert_cmd = Node(
+    problem_expert_cmd = Node(
         package='plansys2_problem_expert',
         executable='problem_expert_node',
         name='problem_expert',
         namespace=namespace,
         output='screen',
-        parameters=[{'model_file': model_file}, params_file])
+        parameters=[{'model_file': model_file}, {'problem_file': problem_file}, params_file])
 
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Set environment variables
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_problem_file_cmd)
     ld.add_action(declare_namespace_cmd)
 
     # Declare the launch options
-    ld.add_action(domain_expert_cmd)
+    ld.add_action(problem_expert_cmd)
 
     return ld


### PR DESCRIPTION
- Add extra launch argument to `problem_expert_launch.py` named `problem_file`.
- Changed `plansys2_bringup_launch_distributed.py` to be able to handle the new argument.
- Renamed `domain_expert_cmd` to `problem_expert_cmd` in `problem_expert_launch.py`, probably a typo.

Now PlanSys2 can be launched (in python launch file) with `domain.pddl` and `problem.pddl` like so:

```python
    plansys2_cmd = IncludeLaunchDescription(
        PythonLaunchDescriptionSource(os.path.join(
            get_package_share_directory('plansys2_bringup'),
            'launch',
            'plansys2_bringup_launch_distributed.py')),
        launch_arguments={
          'model_file': '/tmp/domain.pddl',
          'problem_file': '/tmp/problem.pddl',
          'namespace': namespace
          }.items())
```

NOTE: You still need to create a plan and start (run) the plan.