### PR TITLE
Make `ProblemExpert` case-insensitive to Instance types

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -41,19 +41,29 @@ ProblemExpert::ProblemExpert(std::shared_ptr<DomainExpert> & domain_expert)
 bool
 ProblemExpert::addInstance(const plansys2::Instance & instance)
 {
-  if (!isValidType(instance.type)) {
+  plansys2::Instance lowercase_instance = instance;
+  std::transform(
+    lowercase_instance.type.begin(), lowercase_instance.type.end(), lowercase_instance.type.begin(),
+    [](unsigned char c) {return std::tolower(c);});
+  for (auto i = 0; i < lowercase_instance.sub_types.size(); ++i) {
+    std::transform(
+      lowercase_instance.sub_types[i].begin(), lowercase_instance.sub_types[i].end(),
+      lowercase_instance.sub_types[i].begin(), [](unsigned char c) {return std::tolower(c);});
+  }
+
+  if (!isValidType(lowercase_instance.type)) {
     return false;
   }
 
-  std::optional<plansys2::Instance> existing_instance = getInstance(instance.name);
+  std::optional<plansys2::Instance> existing_instance = getInstance(lowercase_instance.name);
   bool exist_instance = existing_instance.has_value();
 
-  if (exist_instance && existing_instance.value().type != instance.type) {
+  if (exist_instance && existing_instance.value().type != lowercase_instance.type) {
     return false;
   }
 
   if (!exist_instance) {
-    instances_.push_back(instance);
+    instances_.push_back(lowercase_instance);
   }
 
   return true;
@@ -398,8 +408,13 @@ ProblemExpert::clearKnowledge()
 bool
 ProblemExpert::isValidType(const std::string & type)
 {
+  std::string lowercase_type = type;
+  std::transform(
+    lowercase_type.begin(), lowercase_type.end(), lowercase_type.begin(),
+    [](unsigned char c) {return std::tolower(c);});
+
   auto valid_types = domain_expert_->getTypes();
-  auto it = std::find(valid_types.begin(), valid_types.end(), type);
+  auto it = std::find(valid_types.begin(), valid_types.end(), lowercase_type);
 
   return it != valid_types.end();
 }

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -47,17 +47,22 @@ TEST(problem_expert, addget_instances)
         "Paco",
         "SCIENTIFIC")));
   ASSERT_TRUE(problem_expert.addInstance(parser::pddl::fromStringParam("r2d2", "robot")));
+  ASSERT_TRUE(problem_expert.addInstance(parser::pddl::fromStringParam("ur5e", "Robot")));
 
-  ASSERT_EQ(problem_expert.getInstances().size(), 2);
+  ASSERT_EQ(problem_expert.getInstances().size(), 3);
   ASSERT_EQ(problem_expert.getInstances()[0].name, "Paco");
   ASSERT_EQ(problem_expert.getInstances()[0].type, "person");
   ASSERT_EQ(problem_expert.getInstances()[1].name, "r2d2");
   ASSERT_EQ(problem_expert.getInstances()[1].type, "robot");
+  ASSERT_EQ(problem_expert.getInstances()[2].name, "ur5e");
+  ASSERT_EQ(problem_expert.getInstances()[2].type, "robot");
 
   ASSERT_TRUE(problem_expert.removeInstance(parser::pddl::fromStringParam("Paco", "person")));
-  ASSERT_EQ(problem_expert.getInstances().size(), 1);
+  ASSERT_EQ(problem_expert.getInstances().size(), 2);
   ASSERT_EQ(problem_expert.getInstances()[0].name, "r2d2");
   ASSERT_EQ(problem_expert.getInstances()[0].type, "robot");
+  ASSERT_EQ(problem_expert.getInstances()[1].name, "ur5e");
+  ASSERT_EQ(problem_expert.getInstances()[1].type, "robot");
 
   auto paco_instance = problem_expert.getInstance("Paco");
   ASSERT_FALSE(paco_instance);
@@ -65,6 +70,10 @@ TEST(problem_expert, addget_instances)
   ASSERT_TRUE(r2d2_instance);
   ASSERT_EQ(r2d2_instance.value().name, "r2d2");
   ASSERT_EQ(r2d2_instance.value().type, "robot");
+  auto ur5e_instance = problem_expert.getInstance("ur5e");
+  ASSERT_TRUE(ur5e_instance);
+  ASSERT_EQ(ur5e_instance.value().name, "ur5e");
+  ASSERT_EQ(ur5e_instance.value().type, "robot");
 }
 
 TEST(problem_expert, add_functions)
@@ -571,6 +580,11 @@ TEST(problem_expert, add_problem)
   ASSERT_TRUE(problem_expert.isValidType("room"));
   ASSERT_TRUE(problem_expert.isValidType("room_with_teleporter"));
   ASSERT_TRUE(problem_expert.isValidType("message"));
+  ASSERT_TRUE(problem_expert.isValidType("ROBOT"));
+  ASSERT_TRUE(problem_expert.isValidType("Person"));
+  ASSERT_TRUE(problem_expert.isValidType("ROOM"));
+  ASSERT_TRUE(problem_expert.isValidType("ROOM_with_TELEPORTER"));
+  ASSERT_TRUE(problem_expert.isValidType("Message"));
 
   ASSERT_EQ(problem_expert.getInstances().size(), 5);
   ASSERT_EQ(problem_expert.getPredicates().size(), 2);


### PR DESCRIPTION
Closes #280 

My interpretation here is that Instance _names_ should be case-sensitive, but instance _types_ shouldn't be.