### PR TITLE
Add Imply to PDDL domain parsing

### DIFF
--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PDDL-PARSER-SOURCES
   src/plansys2_pddl_parser/Ground.cpp
   src/plansys2_pddl_parser/Utils.cpp
   src/plansys2_pddl_parser/TypeGround.cpp
+  src/plansys2_pddl_parser/Imply.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${PDDL-PARSER-SOURCES})

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
@@ -314,19 +314,6 @@ public:
 		actions.insert( a );
 	}
 
-	// void parseImply( Stringreader & f ) {
-	// 	if ( !preds.size() ) {
-	// 		std::cout << "Predicates needed before defining derived predicates\n";
-	// 		exit(1);
-	// 	}
-
-	// 	f.next();
-	// 	Imply * d = new Imply;
-	// 	d->parse( f, types[0]->constants, *this );
-
-	// 	if ( DOMAIN_DEBUG ) std::cout << d << "\n";
-	// 	derived.insert( d );
-	// }
 
 	// Return a copy of the type structure, with newly allocated types
 	// This will also copy all constants and objects!

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
@@ -9,6 +9,7 @@
   #include "plansys2_pddl_parser/Forall.h"
   #include "plansys2_pddl_parser/Function.h"
   #include "plansys2_pddl_parser/GroundFunc.h"
+  #include "plansys2_pddl_parser/Imply.h"
   #include "plansys2_pddl_parser/FunctionModifier.h"
 
   #include "plansys2_pddl_parser/Not.h"
@@ -313,6 +314,19 @@ public:
 		actions.insert( a );
 	}
 
+	// void parseImply( Stringreader & f ) {
+	// 	if ( !preds.size() ) {
+	// 		std::cout << "Predicates needed before defining derived predicates\n";
+	// 		exit(1);
+	// 	}
+
+	// 	f.next();
+	// 	Imply * d = new Imply;
+	// 	d->parse( f, types[0]->constants, *this );
+
+	// 	if ( DOMAIN_DEBUG ) std::cout << d << "\n";
+	// 	derived.insert( d );
+	// }
 
 	// Return a copy of the type structure, with newly allocated types
 	// This will also copy all constants and objects!
@@ -603,6 +617,7 @@ public:
 		if ( s == "and" ) return new And;
 		if ( s == "exists" ) return new Exists;
 		if ( s == "forall" ) return new Forall;
+		if ( s == "imply" ) return new Imply;
 		if ( s == "assign" ) return new Assign;
 		if ( s == "increase" ) return new Increase;
 		if ( s == "decrease" ) return new Decrease;

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
@@ -1,0 +1,49 @@
+
+#pragma once
+
+#include "plansys2_msgs/msg/node.hpp"
+#include "plansys2_msgs/msg/tree.hpp"
+
+#include "plansys2_pddl_parser/ParamCond.h"
+
+namespace parser { namespace pddl {
+
+class Imply : public ParamCond {
+
+public:
+	Condition * cond;
+
+	Imply()
+		: cond( 0 ) {}
+
+	Imply( const Imply * f, Domain & d )
+		: ParamCond( f ), cond( 0 ) {
+		if ( f->cond ) cond = f->cond->copy( d );
+	}
+
+	~Imply() {
+		if ( cond ) delete cond;
+	}
+
+	void print( std::ostream & s ) const {
+		s << "Imply" << params << ":\n";
+		if ( cond ) cond->print( s );
+	}
+
+	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
+
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+
+	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
+
+	void addParams( int m, unsigned n ) {
+		cond->addParams( m, n );
+	}
+
+	Condition * copy( Domain & d ) {
+		return new Imply( this, d );
+	}
+
+};
+
+} } // namespaces

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -1,0 +1,52 @@
+
+#include "plansys2_pddl_parser/Domain.h"
+
+namespace parser { namespace pddl {
+
+void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const {
+	tabindent( s, indent );
+	s << "( imply\n";
+
+	TokenStruct< std::string > fstruct( ts );
+
+	tabindent( s, indent + 1 );
+	printParams( 0, s, fstruct, d );
+
+	if ( cond ) cond->PDDLPrint( s, indent + 1, fstruct, d );
+	else {
+		tabindent( s, indent + 1 );
+		s << "()";
+	}
+
+	s << "\n";
+	tabindent( s, indent );
+	s << ")";
+}
+
+plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+    throw UnsupportedConstruct("Imply");
+}
+
+void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {
+	f.next();
+	f.assert_token( "(" );
+
+	TokenStruct< std::string > fs = f.parseTypedList( true, d.types );
+	params = d.convertTypes( fs.types );
+
+	TokenStruct< std::string > fstruct( ts );
+	fstruct.append( fs );
+
+	f.next();
+	f.assert_token( "(" );
+	if ( f.getChar() != ')' ) {
+		cond = d.createCondition( f );
+		cond->parse( f, fstruct, d );
+	}
+	else ++f.c;
+
+	f.next();
+	f.assert_token( ")" );
+}
+
+} } // namespaces

--- a/plansys2_pddl_parser/test/pddl/dom1.pddl
+++ b/plansys2_pddl_parser/test/pddl/dom1.pddl
@@ -58,4 +58,25 @@
     )
 )
 
+(:durative-action action_test3
+    :parameters (?r - robot)
+    :duration ( = ?duration 20)
+    :condition (and
+        (at start
+            (forall
+                (?ro - room)
+                (imply
+                    (robot_at ?r ?ro)
+                    (charging_point_at ?ro)
+                )
+            )
+        )
+        (over all (and (> (battery_level ?r) 1) (< (battery_level ?r) 200)) )
+    )
+    :effect (and
+         (at end (increase (battery_level ?r) (* ?duration 5.0)))
+         (at end (battery_full ?r))
+    )
+)
+
 )


### PR DESCRIPTION
I was running PlanSys2 with a PDDL domain that had an `imply` in it, and noticed we did not support it.

So, now we do! Thankfully it was basically copypasta from the `forall` implementation that was already there... and it works :)

Closes https://github.com/PlanSys2/ros2_planning_system/issues/169