### PR TITLE
Do not segfault with filesystem errors in POPF, and allow ~ for home directory

### DIFF
--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -15,6 +15,7 @@
 #ifndef PLANSYS2_POPF_PLAN_SOLVER__POPF_PLAN_SOLVER_HPP_
 #define PLANSYS2_POPF_PLAN_SOLVER__POPF_PLAN_SOLVER_HPP_
 
+#include <filesystem>
 #include <optional>
 #include <memory>
 #include <string>
@@ -30,6 +31,8 @@ private:
   std::string arguments_parameter_name_;
   std::string output_dir_parameter_name_;
   rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node_;
+
+  std::optional<std::filesystem::path> create_folders(const std::string & node_namespace);
 
 public:
   POPFPlanSolver();

--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -32,10 +32,10 @@ private:
   std::string output_dir_parameter_name_;
   rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node_;
 
-  std::optional<std::filesystem::path> create_folders(const std::string & node_namespace);
-
 public:
   POPFPlanSolver();
+
+  std::optional<std::filesystem::path> create_folders(const std::string & node_namespace);
 
   void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr, const std::string &);
 

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -32,19 +32,19 @@ POPFPlanSolver::POPFPlanSolver()
 {
 }
 
-std::optional<std::filesystem::path> POPFPlanSolver::create_folders(const std::string & node_namespace)
+std::optional<std::filesystem::path>
+POPFPlanSolver::create_folders(const std::string & node_namespace)
 {
   auto output_dir = lc_node_->get_parameter(output_dir_parameter_name_).value_to_string();
 
   // Allow usage of the HOME directory with the `~` character, returning if there is an error.
-  const char* home_dir = std::getenv("HOME");
-  if (output_dir[0] == '~' && home_dir)
-  {
+  const char * home_dir = std::getenv("HOME");
+  if (output_dir[0] == '~' && home_dir) {
     output_dir.replace(0, 1, home_dir);
-  }
-  else if (!home_dir)
-  {
-    RCLCPP_ERROR(lc_node_->get_logger(), "Invalid use of the ~ character in the path: %s", output_dir.c_str());
+  } else if (!home_dir) {
+    RCLCPP_ERROR(
+      lc_node_->get_logger(), "Invalid use of the ~ character in the path: %s", output_dir.c_str()
+    );
     return std::nullopt;
   }
 
@@ -58,7 +58,7 @@ std::optional<std::filesystem::path> POPFPlanSolver::create_folders(const std::s
     }
     try {
       std::filesystem::create_directories(output_path);
-    } catch (std::filesystem::filesystem_error& err) {
+    } catch (std::filesystem::filesystem_error & err) {
       RCLCPP_ERROR(lc_node_->get_logger(), "Error writing directories: %s", err.what());
       return std::nullopt;
     }
@@ -94,7 +94,7 @@ POPFPlanSolver::getPlan(
   if (!output_dir_maybe) {
     return {};
   }
-  const auto& output_dir = output_dir_maybe.value();
+  const auto & output_dir = output_dir_maybe.value();
   RCLCPP_INFO(
     lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
 
@@ -174,12 +174,13 @@ POPFPlanSolver::isDomainValid(
   if (!output_dir_maybe) {
     return {};
   }
-  const auto& output_dir = output_dir_maybe.value();
+  const auto & output_dir = output_dir_maybe.value();
   RCLCPP_INFO(
     lc_node_->get_logger(), "Writing domain validation results to %s.",
     output_dir.string().c_str()
   );
 
+  // Perform domain validation
   const auto domain_file_path = output_dir / std::filesystem::path("check_domain.pddl");
   std::ofstream domain_out(domain_file_path);
   domain_out << domain;

--- a/plansys2_popf_plan_solver/test/unit/popf_test.cpp
+++ b/plansys2_popf_plan_solver/test/unit/popf_test.cpp
@@ -54,6 +54,20 @@ void test_plan_generation(const std::string & argument = "")
   ASSERT_EQ(plan.value().items[2].action, "(talk leia jack jack m1)");
 }
 
+std::optional<std::filesystem::path> test_folder_creation(
+  const std::string & output_dir = "", const std::string & node_namespace = "")
+{
+  auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto planner = std::make_shared<plansys2::POPFPlanSolver>();
+
+  planner->configure(node, "POPF");
+  if (!output_dir.empty()) {
+    node->set_parameter(rclcpp::Parameter("POPF.output_dir", output_dir));
+  }
+
+  return planner->create_folders(node_namespace);
+}
+
 TEST(popf_plan_solver, generate_plan_good)
 {
   test_plan_generation();
@@ -95,7 +109,6 @@ TEST(popf_plan_solver, check_1_ok_domain)
   ASSERT_TRUE(result);
 }
 
-
 TEST(popf_plan_solver, check_2_error_domain)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_popf_plan_solver");
@@ -112,7 +125,6 @@ TEST(popf_plan_solver, check_2_error_domain)
 
   ASSERT_FALSE(result);
 }
-
 
 TEST(popf_plan_solver, generate_plan_unsolvable)
 {
@@ -156,6 +168,44 @@ TEST(popf_plan_solver, generate_plan_error)
   auto plan = planner->getPlan(domain_str, problem_str);
 
   ASSERT_FALSE(plan);
+}
+
+TEST(popf_plan_solver, create_folder_default)
+{
+  const auto output_dir = test_folder_creation();
+  ASSERT_TRUE(output_dir.has_value());
+  EXPECT_EQ(output_dir.value(), std::filesystem::temp_directory_path());
+}
+
+TEST(popf_plan_solver, create_folder_custom_path)
+{
+  const auto test_path = std::filesystem::temp_directory_path() / "test" / "path" / "one";
+  const auto output_dir = test_folder_creation(test_path);
+  ASSERT_TRUE(output_dir.has_value());
+  EXPECT_EQ(output_dir.value(), test_path);
+}
+
+TEST(popf_plan_solver, create_folder_custom_path_and_namespace)
+{
+  const auto test_path = std::filesystem::temp_directory_path() / "test" / "path" / "two";
+  const auto test_namespace = "/test/node";
+  const auto output_dir = test_folder_creation(test_path, test_namespace);
+  ASSERT_TRUE(output_dir.has_value());
+  EXPECT_EQ(output_dir.value(), test_path / "test" / "node");
+}
+
+TEST(popf_plan_solver, create_folder_filesystem_error)
+{
+  const auto test_path = std::filesystem::temp_directory_path() / "test" / "path" / "three";
+
+  // Create a file at the test path to force a filesystem error
+  std::ofstream out(test_path);
+  out << "random text\n";
+  out.close();
+
+  const auto test_namespace = "/test/node";
+  const auto output_dir = test_folder_creation(test_path, test_namespace);
+  ASSERT_FALSE(output_dir.has_value());
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
This PR adds 3 improvements to specifying the planning folder in POPF.

1. Do not segfault if there is a filesystem error creating folders, simply log an error and return early.
2. Allow the use of `~` in the output folder parameter, which resolves to the user's home folder.
3. Reduced copypaste between the same code in planning vs. domain validation.

If this looks good, I'll do the same for the TFD solver.