### PR TITLE
Removed some small references still related to the old version of BehaviorTree.CPP 3.8

### DIFF
--- a/plansys2_bt_actions/CMakeLists.txt
+++ b/plansys2_bt_actions/CMakeLists.txt
@@ -68,6 +68,5 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_dependencies(${dependencies})
-include_directories(include)
 
 ament_package()

--- a/plansys2_bt_actions/package.xml
+++ b/plansys2_bt_actions/package.xml
@@ -18,7 +18,6 @@
   <depend>plansys2_executor</depend>
   <depend>behaviortree_cpp</depend>
   <depend>action_msgs</depend>
-  <depend>libzmq3-dev</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_bt_actions/test/behavior_tree/assemble.xml
+++ b/plansys2_bt_actions/test/behavior_tree/assemble.xml
@@ -1,4 +1,4 @@
-<root main_tree_to_execute = "MainTree" >
+<root BTCPP_format="4" main_tree_to_execute = "MainTree" >
     <BehaviorTree ID="MainTree">
        <Sequence name="root_sequence">
            <OpenGripper    name="open_gripper"/>

--- a/plansys2_bt_actions/test/behavior_tree/transport.xml
+++ b/plansys2_bt_actions/test/behavior_tree/transport.xml
@@ -1,4 +1,4 @@
-<root main_tree_to_execute = "MainTree" >
+<root BTCPP_format="4" main_tree_to_execute = "MainTree" >
     <BehaviorTree ID="MainTree">
        <Sequence name="root_sequence">
            <Move           name="move" goal="${arg2}"  goal_reached="${goal_reached}"/>

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -441,7 +441,7 @@ class ExecuteActionTest : public plansys2::ExecuteAction
 public:
   ExecuteActionTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : ExecuteAction(xml_tag_name, conf) {}
 
   void halt() override
@@ -466,7 +466,7 @@ class WaitActionTest : public plansys2::WaitAction
 public:
   WaitActionTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : WaitAction(xml_tag_name, conf) {}
 
   void halt() override
@@ -490,7 +490,7 @@ class CheckOverAllReqTest : public plansys2::CheckOverAllReq
 public:
   CheckOverAllReqTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : CheckOverAllReq(xml_tag_name, conf) {}
 
   void halt() override
@@ -514,7 +514,7 @@ class WaitAtStartReqTest : public plansys2::WaitAtStartReq
 public:
   WaitAtStartReqTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : WaitAtStartReq(xml_tag_name, conf) {}
 
   void halt() override
@@ -538,7 +538,7 @@ class CheckAtEndReqTest : public plansys2::CheckAtEndReq
 public:
   CheckAtEndReqTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : CheckAtEndReq(xml_tag_name, conf) {}
 
   void halt() override
@@ -562,7 +562,7 @@ class ApplyAtStartEffectTest : public plansys2::ApplyAtStartEffect
 public:
   ApplyAtStartEffectTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : ApplyAtStartEffect(xml_tag_name, conf) {}
 
   void halt() override
@@ -586,7 +586,7 @@ class ApplyAtEndEffectTest : public plansys2::ApplyAtEndEffect
 public:
   ApplyAtEndEffectTest(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf)
+    const BT::NodeConfig & conf)
   : ApplyAtEndEffect(xml_tag_name, conf) {}
 
   void halt() override


### PR DESCRIPTION
I removed references/refusals still related to the old version of _Behavior Tree V3.8_. In particular:

- In the `plansys2_bt_actions` package in the `CmakeLists` there was a repetition of `include_directories(include) `and in the `package.xml` there was still the dependency to `libzmq3-dev` related to `zmq_publisher` for BT V3.8 communication with Groot which was removed from the latest PR.
- I added the `BTCPP_format="4"` in two BT xmls where it did not appear.
- In `plansys2_executor` there was still the old reference to `BT::NodeConfiguration` now `BT::NodeConfig` in `BT 4.x` naming convention.