### PR TITLE
[pddl_parser] Fix support for disjunctive-preconditions

### DIFF
--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
@@ -135,7 +135,7 @@ public:
 		else if ( s == "non-deterministic" ) nondet = true;
 		else if ( s == "universal-preconditions" ) universal = true;
 		else if ( s == "fluents" ) fluents = true;
-		else if ( s == "disjuntive-preconditions" ) disj = true;
+		else if ( s == "disjunctive-preconditions" ) disj = true;
 		else if ( s == "derived-predicates" ) derivedpred = true;
 		else return false; // Unknown requirement
 
@@ -590,7 +590,7 @@ public:
 		if ( nondet ) os << " :non-deterministic";
 		if ( universal ) os << " :universal-preconditions";
 		if ( fluents ) os << " :fluents";
-		if ( disj ) os << " :disjuntive-preconditions";
+		if ( disj ) os << " :disjunctive-preconditions";
 		if ( derivedpred ) os << " :derived-predicates";
 		os << " )\n";
 		return os;


### PR DESCRIPTION

This fixes a typo which affected the support of disjunctive preconditions 