### PR TITLE
[executor] ExecutorNode, remove unused ros node

### DIFF
--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -74,8 +74,6 @@ public:
     const std::shared_ptr<plansys2_msgs::srv::GetPlan::Response> response);
 
 protected:
-  rclcpp::Node::SharedPtr node_;
-
   bool cancel_plan_requested_;
   std::optional<plansys2_msgs::msg::Plan> current_plan_;
   std::optional<std::vector<plansys2_msgs::msg::Tree>> ordered_sub_goals_;


### PR DESCRIPTION
This PR removes an unused member (of type rclcpp::Node) unnecessarily owned by the ExecutorNode.