### PR TITLE
[executor] Send Cancelation response to ActionClient

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -545,7 +545,11 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   }
 
   if (rclcpp::ok()) {
-    goal_handle->succeed(result);
+    if (cancel_plan_requested_) {
+      goal_handle->canceled(result);
+    } else {
+      goal_handle->succeed(result);
+    }
     if (result->success) {
       RCLCPP_INFO(this->get_logger(), "Plan Succeeded");
     } else {


### PR DESCRIPTION
Currently, When the ExecutorNode (i.e., ActionServer) receives cancellation of `execute_plan` goal, it halts the execution of the behavior tree. It is also desired that action-servers send a cancellation response. This allows the action-client to trigger on_cancellation hooks to finalize their goal.