### PR TITLE
[executor] fail execute_plan action if initial conditions changed

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -313,8 +313,13 @@ ComputeBT::computeBTCallback(
   auto bt_xml_tree = bt_builder->get_tree(plan.value());
   if (bt_xml_tree.empty()) {
     RCLCPP_ERROR(get_logger(), "Error computing behavior tree!");
+   
+    finish = true;
+    t.join();
+    response->success = false;
     return;
   }
+
   saveBT(bt_xml_tree, problem_path.stem().u8string());
 
   auto action_graph = bt_builder->get_graph();

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -313,7 +313,7 @@ ComputeBT::computeBTCallback(
   auto bt_xml_tree = bt_builder->get_tree(plan.value());
   if (bt_xml_tree.empty()) {
     RCLCPP_ERROR(get_logger(), "Error computing behavior tree!");
-   
+
     finish = true;
     t.join();
     response->success = false;

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -428,6 +428,12 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   auto bt_xml_tree = bt_builder->get_tree(current_plan_.value());
   if (bt_xml_tree.empty()) {
     RCLCPP_ERROR(get_logger(), "Error computing behavior tree!");
+
+    result->success = false;
+    goal_handle->succeed(result);
+
+    // Publish void plan
+    executing_plan_pub_->publish(plansys2_msgs::msg::Plan());
     return;
   }
 

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -426,7 +426,12 @@ SimpleBTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
       std::cerr << "[ERROR] requirement not met: [" <<
         parser::pddl::toString(req) << "]" << std::endl;
     }
-    assert(requirements.empty());
+
+    // Return and empyt graph to fail the serveice call
+    if(!requirements.empty())
+    {
+      return nullptr;
+    }
 
     action_sequence.erase(action_sequence.begin());
   }
@@ -438,6 +443,12 @@ std::string
 SimpleBTBuilder::get_tree(const plansys2_msgs::msg::Plan & current_plan)
 {
   graph_ = get_graph(current_plan);
+
+  // If graph was not generated, return an empty string.
+  // This can be used to fails the serveice call
+  if (!graph_) {
+    return "";
+  }
 
   std::list<ActionNode::Ptr> used_actions;
   for (auto & root : graph_->roots) {

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -428,8 +428,7 @@ SimpleBTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     }
 
     // Return and empyt graph to fail the serveice call
-    if(!requirements.empty())
-    {
+    if (!requirements.empty()) {
       return nullptr;
     }
 


### PR DESCRIPTION
We terminate the program is many scenarios instead of just returning an explicit value. We currently terminate if the initial conditions change before the plan is started. This is prone to happen in the real world.

This PR sends an explicit result with a failure result to "execute_plan" goals for which the initial requirements change after planning and before execution.

* FEATURE:  [ComputeBT] Response with failure when unable to build tree
* FIX:  [ComputeBT] Joins thread when unable to build tree
* FEATURE:  [ExecutorNode] Send Result with failure when unable to build tree and publish an empty plan
* FIX: [simple_bt_builder] Don't terminate the program when requirements change. instead, return explicit values
