### PR TITLE
Fix POPF error with empty problem

### DIFF
--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -188,7 +188,7 @@ POPFPlanSolver::isDomainValid(
 
   const auto problem_file_path = output_dir / std::filesystem::path("check_problem.pddl");
   std::ofstream problem_out(problem_file_path);
-  problem_out << "(define (problem void) (:domain plansys2))";
+  problem_out << "(define (problem void) (:domain plansys2) (:objects ) (:init ) (:goal (and ) ))";
   problem_out.close();
 
   const auto plan_file_path = output_dir / std::filesystem::path("check.out");


### PR DESCRIPTION
We found that, in some cases, POPF segfaults when the problem definition does not include the :objects, :init and :goal sections. That caused the domain_expert to report a "PDDL syntax error" message and crash.
The issue happens when checking if a domain is valid, because an empty problem is auto-generated and passed to POPF.

This PR should fix this issue.
