### PR TITLE
[executor] ActionExecutor, finialze on cancel, its cancel and forget

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
@@ -162,6 +162,7 @@ ActionExecutor::get_status()
       return BT::NodeStatus::SUCCESS;
       break;
     case FAILURE:
+    case CANCELLED:
       return BT::NodeStatus::FAILURE;
       break;
     default:
@@ -229,6 +230,10 @@ ActionExecutor::cancel()
   msg.arguments = action_params_;
 
   action_hub_pub_->publish(msg);
+
+  action_hub_pub_->on_deactivate();
+  action_hub_pub_ = nullptr;
+  action_hub_sub_ = nullptr;
 }
 
 std::string


### PR DESCRIPTION
Not sure yet if this is required Since when we cancel in a fire-and-forget fashion it might be needed to finalize and deactivate the publisher upon cancellation. 