### PR TITLE
[lifecycle_manager] Activate planner first

### DIFF
--- a/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
+++ b/plansys2_lifecycle_manager/src/plansys2_lifecycle_manager/lifecycle_manager.cpp
@@ -127,6 +127,22 @@ startup_function(
   std::map<std::string, std::shared_ptr<LifecycleServiceClient>> & manager_nodes,
   std::chrono::seconds timeout)
 {
+  // configure planner
+  {
+    if (!manager_nodes["planner"]->change_state(
+        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+        timeout))
+    {
+      return false;
+    }
+
+    while (manager_nodes["planner"]->get_state() !=
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+    {
+      std::cerr << "Waiting for inactive state for planner" << std::endl;
+    }
+  }
+
   // configure domain_expert
   {
     if (!manager_nodes["domain_expert"]->change_state(
@@ -156,22 +172,6 @@ startup_function(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
     {
       std::cerr << "Waiting for inactive state for problem_expert" << std::endl;
-    }
-  }
-
-  // configure planner
-  {
-    if (!manager_nodes["planner"]->change_state(
-        lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
-        timeout))
-    {
-      return false;
-    }
-
-    while (manager_nodes["planner"]->get_state() !=
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-    {
-      std::cerr << "Waiting for inactive state for planner" << std::endl;
     }
   }
 


### PR DESCRIPTION
I believe the planner should be activated first. 
When the domain_expert  `validate_using_planner_node` parameter is set to `true`, it waits for the planner's service `/planner/validate_domain`.