### PR TITLE
include "object" in getType

### DIFF
--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -55,7 +55,7 @@ DomainExpert::getTypes()
 {
   std::vector<std::string> ret;
   if (domain_->typed) {
-    for (unsigned i = 1; i < domain_->types.size(); i++) {
+    for (unsigned i = 0; i < domain_->types.size(); i++) {
       ret.push_back(domain_->types[i]->name);
     }
   }

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -146,7 +146,8 @@ TEST(domain_expert, get_types)
   plansys2::DomainExpert domain_expert(domain_str);
 
   std::vector<std::string> types = domain_expert.getTypes();
-  std::vector<std::string> test_types {"person", "message", "robot", "room", "teleporter_room"};
+  std::vector<std::string> test_types {"object", "person", "message", "robot",
+    "room", "teleporter_room"};
 
   ASSERT_EQ(types, test_types);
 }
@@ -355,8 +356,8 @@ TEST(domain_expert, multidomain_get_types)
   domain_expert->extendDomain(domain_ext_str);
 
   std::vector<std::string> types = domain_expert->getTypes();
-  std::vector<std::string> test_types {"person", "message", "robot", "room", "teleporter_room",
-    "pickable_object"};
+  std::vector<std::string> test_types {"object", "person", "message", "robot", "room",
+    "teleporter_room", "pickable_object"};
 
   ASSERT_EQ(types, test_types);
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
@@ -218,11 +218,6 @@ public:
 		for ( unsigned i = 0; i < ts.size(); ++i ) {
 			Type * t = getType( ts.types[i] );
 			t->constants.insert(ts[i]);
-			// We need to populate the constants of all supertypes
-			while(t->supertype != nullptr) {
-				t = t->supertype;
-				t->constants.insert(ts[i]);
-			}
 		}
 		for ( unsigned i = 0; DOMAIN_DEBUG && i < types.size(); ++i ) {
 			std::cout << " ";


### PR DESCRIPTION
Return the "object" type in the  `getType` method, as instances could be defined with the object type since it is included by default.

Also, I don´t understand why the following is necessary:
https://github.com/PlanSys2/ros2_planning_system/blob/a7971965431fc5c837074e6a15059650f75645b8/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h#L221-L225

It basically creates duplicates of the constants for all its supertypes. Is this really needed?

Related to #317 