### PR TITLE
Support negation of CompositeExpression

### DIFF
--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Not.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Not.h
@@ -12,7 +12,7 @@ class Not : public Condition {
 
 public:
 
-	Ground * cond;
+	Condition * cond;
 
 	Not()
 		: cond( 0 ) {}

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Action.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Action.cpp
@@ -116,7 +116,8 @@ GroundVec Action::getGroundsFromCondition( Condition * c, bool neg ) {
 	for ( unsigned i = 0; a && i < a->conds.size(); ++i ) {
 		if ( neg ) {
 			Not * n = dynamic_cast< Not * >( a->conds[i] );
-			if ( n ) grounds.push_back( n->cond );
+			Ground * g = dynamic_cast< Ground * >( n->cond );
+			if ( n && g) grounds.push_back( g );
 		}
 		else {
 			Ground * g = dynamic_cast< Ground * >( a->conds[i] );
@@ -126,7 +127,8 @@ GroundVec Action::getGroundsFromCondition( Condition * c, bool neg ) {
 
 	if ( neg ) {
 		Not * n = dynamic_cast< Not * >( c );
-		if ( n ) grounds.push_back( n->cond );
+		Ground * g = dynamic_cast< Ground * >( n->cond );
+		if ( n && g) grounds.push_back( g );
 	}
 	else {
 		Ground * g = dynamic_cast< Ground * >( c );

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Not.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Not.cpp
@@ -28,7 +28,7 @@ void Not::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d )
 	f.next();
 	f.assert_token( "(" );
 
-	cond = dynamic_cast< Ground * >( d.createCondition( f ) );
+	cond = d.createCondition( f );
 
 	if ( !cond ) {
 		f.tokenExit( f.getToken() );

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -575,7 +575,6 @@ std::string toStringNot(const plansys2_msgs::msg::Tree & tree, uint32_t node_id,
   if (tree.nodes[node_id].children.empty()) {
     return {};
   }
-
   return toString(tree, tree.nodes[node_id].children[0], !negate);
 }
 
@@ -590,22 +589,25 @@ std::string toStringExpression(const plansys2_msgs::msg::Tree & tree, uint32_t n
   }
 
   std::string ret;
+  if (negate) {
+    ret = "(not ";
+  }
 
   switch (tree.nodes[node_id].expression_type) {
     case plansys2_msgs::msg::Node::COMP_GE:
-      ret = "(>= ";
+      ret += "(>= ";
       break;
     case plansys2_msgs::msg::Node::COMP_GT:
-      ret = "(> ";
+      ret += "(> ";
       break;
     case plansys2_msgs::msg::Node::COMP_LE:
-      ret = "(<= ";
+      ret += "(<= ";
       break;
     case plansys2_msgs::msg::Node::COMP_LT:
-      ret = "(< ";
+      ret += "(< ";
       break;
     case plansys2_msgs::msg::Node::COMP_EQ:
-      ret = "(= ";
+      ret += "(= ";
       break;
     case plansys2_msgs::msg::Node::ARITH_MULT:
       ret = "(* ";
@@ -631,6 +633,9 @@ std::string toStringExpression(const plansys2_msgs::msg::Tree & tree, uint32_t n
     ret += " " + toString(tree, child_id, negate);
   }
   ret += ")";
+  if (negate) {
+    ret += ")";
+  }
 
   return ret;
 }

--- a/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
@@ -174,37 +174,37 @@ std::tuple<bool, bool, double> evaluate(
         switch (tree.nodes[node_id].expression_type) {
           case plansys2_msgs::msg::Node::COMP_GE:
             if (std::get<2>(left) >= std::get<2>(right)) {
-              return std::make_tuple(true, true, 0);
+              return std::make_tuple(true, negate ^ true, 0);
             } else {
-              return std::make_tuple(true, false, 0);
+              return std::make_tuple(true, negate ^ false, 0);
             }
             break;
           case plansys2_msgs::msg::Node::COMP_GT:
             if (std::get<2>(left) > std::get<2>(right)) {
-              return std::make_tuple(true, true, 0);
+              return std::make_tuple(true, negate ^ true, 0);
             } else {
-              return std::make_tuple(true, false, 0);
+              return std::make_tuple(true, negate ^ false, 0);
             }
             break;
           case plansys2_msgs::msg::Node::COMP_LE:
             if (std::get<2>(left) <= std::get<2>(right)) {
-              return std::make_tuple(true, true, 0);
+              return std::make_tuple(true, negate ^ true, 0);
             } else {
-              return std::make_tuple(true, false, 0);
+              return std::make_tuple(true, negate ^ false, 0);
             }
             break;
           case plansys2_msgs::msg::Node::COMP_LT:
             if (std::get<2>(left) < std::get<2>(right)) {
-              return std::make_tuple(true, true, 0);
+              return std::make_tuple(true, negate ^ true, 0);
             } else {
-              return std::make_tuple(true, false, 0);
+              return std::make_tuple(true, negate ^ false, 0);
             }
             break;
           case plansys2_msgs::msg::Node::COMP_EQ:
             if (std::get<2>(left) == std::get<2>(right)) {
-              return std::make_tuple(true, true, 0);
+              return std::make_tuple(true, negate ^ true, 0);
             } else {
-              return std::make_tuple(true, false, 0);
+              return std::make_tuple(true, negate ^ false, 0);
             }
             break;
 

--- a/plansys2_problem_expert/test/unit/utils_test.cpp
+++ b/plansys2_problem_expert/test/unit/utils_test.cpp
@@ -129,6 +129,22 @@ TEST(utils, evaluate_not)
   ASSERT_EQ(
     plansys2::evaluate(test_tree, problem_client, predicates, functions, false, true),
     std::make_tuple(true, false, 0));
+
+  plansys2_msgs::msg::Tree test_tree2;
+  parser::pddl::fromString(
+    test_tree2, "(not (= wp1 wp2))");
+
+  ASSERT_EQ(
+    plansys2::evaluate(test_tree2, problem_client, predicates, functions, false, true),
+    std::make_tuple(true, true, 0));
+
+  plansys2_msgs::msg::Tree test_tree3;
+  parser::pddl::fromString(
+    test_tree3, "(not (= wp1 wp1))");
+
+  ASSERT_EQ(
+    plansys2::evaluate(test_tree3, problem_client, predicates, functions, false, true),
+    std::make_tuple(true, false, 0));
 }
 
 TEST(utils, evaluate_predicate_use_state)


### PR DESCRIPTION
Support negation of CompositeExpression. Something like:

```pddl
(:action move
      :parameters (?wp1 ?wp2 - waypoint)
      :precondition (and
        (not (= ?wp1 ?wp2))
      )
      :effect (and
        (not (robot_at ?wp1))
        (robot_at ?wp2)
      )
)
```

related to #317 