### PR TITLE
Change cascade_lifecycle dependency version to jazzy-devel

### DIFF
--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -2,7 +2,7 @@ repositories:
   cascade_lifecycle:
     type: git
     url: https://github.com/fmrico/cascade_lifecycle.git
-    version: rolling
+    version: jazzy-devel
   popf:
     type: git
     url: https://github.com/fmrico/popf.git


### PR DESCRIPTION
Related to issue #335. In the `jazzy-devel` branch, the required branch for cascade_lifecycle was set to `rolling` instead of `jazzy-devel`.