### PR TITLE
Publisher and Service to know the remaining plan during execution

### DIFF
--- a/plansys2_executor/include/plansys2_executor/ActionExecutor.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutor.hpp
@@ -24,6 +24,7 @@
 #include "plansys2_msgs/msg/action_execution_info.hpp"
 #include "plansys2_msgs/msg/durative_action.hpp"
 #include "plansys2_msgs/msg/param.hpp"
+#include "plansys2_msgs/msg/plan_item.hpp"
 #include "plansys2_pddl_parser/Utils.hpp"
 #include "behaviortree_cpp/behavior_tree.h"
 
@@ -225,6 +226,7 @@ struct ActionVariant
 
 struct ActionExecutionInfo
 {
+  plansys2_msgs::msg::PlanItem plan_item;
   std::shared_ptr<ActionExecutor> action_executor = {nullptr};
   bool at_start_effects_applied = {false};
   bool at_end_effects_applied = {false};

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -45,7 +45,8 @@ public:
   bool execute_and_check_plan();
   void cancel_plan_execution();
   std::vector<plansys2_msgs::msg::Tree> getOrderedSubGoals();
-  std::optional<plansys2_msgs::msg::Plan> getPlan();
+  std::optional<plansys2_msgs::msg::Plan> get_plan();
+  std::optional<plansys2_msgs::msg::Plan> get_remaining_plan();
 
   ExecutePlan::Feedback getFeedBack() {return feedback_;}
   std::optional<ExecutePlan::Result> getResult();
@@ -57,6 +58,7 @@ private:
   rclcpp::Client<plansys2_msgs::srv::GetOrderedSubGoals>::SharedPtr
     get_ordered_sub_goals_client_;
   rclcpp::Client<plansys2_msgs::srv::GetPlan>::SharedPtr get_plan_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetPlan>::SharedPtr get_remaining_plan_client_;
 
   ExecutePlan::Feedback feedback_;
   rclcpp_action::ClientGoalHandle<ExecutePlan>::SharedPtr goal_handle_;

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -73,9 +73,15 @@ public:
     const std::shared_ptr<plansys2_msgs::srv::GetPlan::Request> request,
     const std::shared_ptr<plansys2_msgs::srv::GetPlan::Response> response);
 
+  void get_remaining_plan_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::GetPlan::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::GetPlan::Response> response);
+
 protected:
   bool cancel_plan_requested_;
-  std::optional<plansys2_msgs::msg::Plan> current_plan_;
+  std::optional<plansys2_msgs::msg::Plan> remaining_plan_;
+  std::optional<plansys2_msgs::msg::Plan> complete_plan_;
   std::optional<std::vector<plansys2_msgs::msg::Tree>> ordered_sub_goals_;
 
   std::string action_bt_xml_;
@@ -90,6 +96,7 @@ protected:
   rclcpp_lifecycle::LifecyclePublisher<plansys2_msgs::msg::ActionExecutionInfo>::SharedPtr
     execution_info_pub_;
   rclcpp_lifecycle::LifecyclePublisher<plansys2_msgs::msg::Plan>::SharedPtr executing_plan_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<plansys2_msgs::msg::Plan>::SharedPtr remaining_plan_pub_;
 
   rclcpp_action::Server<ExecutePlan>::SharedPtr execute_plan_action_server_;
   rclcpp::Service<plansys2_msgs::srv::GetOrderedSubGoals>::SharedPtr
@@ -99,6 +106,7 @@ protected:
   std::optional<std::vector<plansys2_msgs::msg::Tree>> getOrderedSubGoals();
 
   rclcpp::Service<plansys2_msgs::srv::GetPlan>::SharedPtr get_plan_service_;
+  rclcpp::Service<plansys2_msgs::srv::GetPlan>::SharedPtr get_remaining_plan_service_;
 
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID & uuid,
@@ -116,6 +124,10 @@ protected:
 
   void print_execution_info(
     std::shared_ptr<std::map<std::string, ActionExecutionInfo>> exec_info);
+
+  void update_plan(
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map,
+    std::optional<plansys2_msgs::msg::Plan> & remaining_plan);
 };
 
 }  // namespace plansys2

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -259,6 +259,7 @@ ComputeBT::computeBTCallback(
 
 
     (*action_map)[index] = ActionExecutionInfo();
+    (*action_map)[index].plan_item = plan_item;
     (*action_map)[index].action_executor =
       ActionExecutor::make_shared(plan_item.action, shared_from_this());
 

--- a/plansys2_executor/test/pddl/simple_move_example.pddl
+++ b/plansys2_executor/test/pddl/simple_move_example.pddl
@@ -1,0 +1,37 @@
+(define (domain replan)
+(:requirements :strips :typing :adl :fluents :durative-actions)
+
+;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:types
+robot
+waypoint
+);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:predicates
+
+
+(robot_at ?r - robot ?wp - waypoint)
+(connected ?wp_from ?wp_to - waypoint)
+
+
+);; end Predicates ;;;;;;;;;;;;;;;;;;;;
+;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:functions
+
+);; end Functions ;;;;;;;;;;;;;;;;;;;;
+;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:durative-action move
+    :parameters (?r - robot ?from ?to - waypoint)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(robot_at ?r ?from))
+        (over all(connected ?from ?to))
+        )
+    :effect (and
+        (at end(not(robot_at ?r ?from)))
+        (at end(robot_at ?r ?to))
+    )
+)
+
+);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -1362,7 +1362,6 @@ TEST(executor, executor_client_execute_plan)
   exe.add_node(move_action_node->get_node_base_interface());
   exe.add_node(test_lf_node->get_node_base_interface());
 
-
   bool finish = false;
   std::thread t([&]() {
       while (!finish) {exe.spin_some();}
@@ -1620,6 +1619,141 @@ TEST(executor, executor_client_execute_plan_2)
   for (const auto & action_status : result.action_execution_status) {
     ASSERT_EQ(action_status.status, plansys2_msgs::msg::ActionExecutionInfo::SUCCEEDED);
   }
+
+  finish = true;
+  t.join();
+}
+
+TEST(executor, executor_client_execute_plan_3)
+{
+  auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
+  auto test_node_2 = rclcpp::Node::make_shared("test_node_2");
+  auto test_node_3 = rclcpp::Node::make_shared("test_node_3");
+  auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+  auto planner_node = std::make_shared<plansys2::PlannerNode>();
+  auto executor_node = std::make_shared<ExecutorNodeTest>();
+
+  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_runtime(2.0);
+
+  auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
+  auto planner_client = std::make_shared<plansys2::PlannerClient>();
+  auto executor_client = std::make_shared<plansys2::ExecutorClient>();
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/simple_move_example.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/simple_move_example.pddl"});
+
+  rclcpp::experimental::executors::EventsExecutor exe;
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+  exe.add_node(planner_node->get_node_base_interface());
+  exe.add_node(executor_node->get_node_base_interface());
+  exe.add_node(move_action_node->get_node_base_interface());
+  exe.add_node(test_lf_node->get_node_base_interface());
+  exe.add_node(test_node_1->get_node_base_interface());
+
+  int changes_plan = 0;
+  plansys2_msgs::msg::Plan current_plan;
+  auto current_plan_sub = test_node_1->create_subscription<plansys2_msgs::msg::Plan>(
+    "/remaining_plan", rclcpp::QoS(100),
+    [&current_plan, &changes_plan](plansys2_msgs::msg::Plan::SharedPtr plan) {
+      if (plan->items.size() != current_plan.items.size()) {
+        changes_plan++;
+      }
+      current_plan = *plan;
+    });
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+    while ((test_node_1->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+    while ((test_node_1->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"r2d2", "robot"}));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"wp1", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"wp2", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"wp3", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"wp4", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance{"wp5", "waypoint"}));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp1 wp2)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp2 wp1)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp2 wp3)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp3 wp2)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp3 wp4)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp4 wp3)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp4 wp5)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(connected wp5 wp4)")));
+  ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate("(robot_at r2d2 wp1)")));
+
+  problem_client->setGoal(plansys2::Goal("(and(robot_at r2d2 wp5))"));
+
+  auto domain = domain_client->getDomain();
+  auto problem = problem_client->getProblem();
+  auto plan = planner_client->getPlan(domain, problem);
+  ASSERT_FALSE(domain.empty());
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
+
+    while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
+      auto feedback = executor_client->getFeedBack();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(problem_client->existPredicate(plansys2::Predicate("(robot_at r2d2 wp5)")));
+
+  ASSERT_TRUE(executor_client->getResult().has_value());
+  auto result = executor_client->getResult().value();
+
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.action_execution_status.size(), 5u);
+  for (const auto & action_status : result.action_execution_status) {
+    ASSERT_EQ(action_status.status, plansys2_msgs::msg::ActionExecutionInfo::SUCCEEDED);
+  }
+
+  ASSERT_EQ(changes_plan, 5);
+  ASSERT_EQ(current_plan.items.size(), 0);
 
   finish = true;
   t.join();


### PR DESCRIPTION
Dear all,

This change is for having a publisher and a service to obtain the remaining plan, i.e., the action still to be executed in the total plan.

I have also changed `getPlan` to `get_plan` to unify styles, although I should do it for all the packages in the future.

I hope it helps!!