### PR TITLE
Fixed problem for debugging in rqt

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -738,6 +738,7 @@ ExecutorNode::execution_cycle()
           runtime_info_ = PlanRuntineInfo();
           runtime_info_.complete_plan = current_goal_handle_->get_goal()->plan;
           runtime_info_.remaining_plan = current_goal_handle_->get_goal()->plan;
+          executing_plan_pub_->publish(runtime_info_.complete_plan);
 
           if (!init_plan_for_execution(runtime_info_)) {
             executor_state_ = STATE_ABORTING;
@@ -765,7 +766,6 @@ ExecutorNode::execution_cycle()
 
           update_plan(runtime_info_);
           remaining_plan_pub_->publish(runtime_info_.remaining_plan);
-          executing_plan_pub_->publish(runtime_info_.complete_plan);
 
           std_msgs::msg::String dotgraph_msg;
           dotgraph_msg.data = runtime_info_.current_tree->bt_builder->get_dotgraph(
@@ -799,6 +799,7 @@ ExecutorNode::execution_cycle()
         
           runtime_info_.complete_plan = current_goal_handle_->get_goal()->plan;
           runtime_info_.remaining_plan = current_goal_handle_->get_goal()->plan;
+          executing_plan_pub_->publish(runtime_info_.complete_plan);
           // runtime_info_.ordered_sub_goals = {};
 
           if (!replan_for_execution(runtime_info_)) {


### PR DESCRIPTION
HI!!!

There was a problem with the rqt display, and it was that the plan was visible but not the execution of it (nor the colors).

The reason was that the plan status was published first and then the plan, and in the rqt node all the status was deleted when a new plan arrived.

There were two solutions:
- Publish the plan first and then the status.
- Publish the plan at the beginning or when it changes.

I have chosen this second action because it would be published less, and also because when viewing it the rqt window was updating much more, and it looked ugly :(

Greetings ^^