### PR TITLE
Implement BehaviourTrees for forall and imply

### DIFF
--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -231,7 +231,7 @@ public:
   }
 
 protected:
-  void cancel_goal()
+  virtual void cancel_goal()
   {
     auto future_cancel = action_client_->async_cancel_goal(goal_handle_);
     if (rclcpp::spin_until_future_complete(

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -125,7 +125,8 @@ public:
    */
   plansys2_msgs::msg::DurativeAction::SharedPtr getDurativeAction(
     const std::string & action,
-    const std::vector<std::string> & params = {});
+    const std::vector<std::string> & params = {},
+    const std::vector<plansys2_msgs::msg::Param> & instances = {});
 
   /// Get the current domain, ready to be saved to file, or to initialize another domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -109,7 +109,8 @@ public:
    */
   plansys2_msgs::msg::Action::SharedPtr getAction(
     const std::string & action,
-    const std::vector<std::string> & params = {});
+    const std::vector<std::string> & params = {},
+    const std::vector<plansys2_msgs::msg::Param> & instances = {});
 
   /// Get the temporal actions existing in the domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -115,7 +115,8 @@ public:
    */
   plansys2_msgs::msg::Action::SharedPtr getAction(
     const std::string & action,
-    const std::vector<std::string> & params = {});
+    const std::vector<std::string> & params = {},
+    const std::vector<plansys2_msgs::msg::Param> & instances = {});
 
   /// Get the temporal actions existing in the domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -131,7 +131,8 @@ public:
    */
   plansys2_msgs::msg::DurativeAction::SharedPtr getDurativeAction(
     const std::string & action,
-    const std::vector<std::string> & params = {});
+    const std::vector<std::string> & params = {},
+    const std::vector<plansys2_msgs::msg::Param> & instances = {});
 
   /// Get the current domain, ready to be saved to file, or to initialize another domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -99,8 +99,8 @@ public:
    *    If the action does not exist, the value returned has not value.
    */
   virtual plansys2_msgs::msg::Action::SharedPtr getAction(
-    const std::string & action, const std::vector<std::string> & params) =
-  0;
+    const std::string & action, const std::vector<std::string> & params,
+    const std::vector<plansys2_msgs::msg::Param> & instances) = 0;
 
   /// Get the temporal actions existing in the domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -115,8 +115,8 @@ public:
    *    effects. If the action does not exist, the value returned has not value.
    */
   virtual plansys2_msgs::msg::DurativeAction::SharedPtr getDurativeAction(
-    const std::string & durative_action, const std::vector<std::string> & params, const std::vector<plansys2_msgs::msg::Param>& instances) =
-  0;
+    const std::string & durative_action, const std::vector<std::string> & params,
+    const std::vector<plansys2_msgs::msg::Param> & instances) = 0;
 
   /// Get the current domain, ready to be saved to file, or to initialize another domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -115,7 +115,7 @@ public:
    *    effects. If the action does not exist, the value returned has not value.
    */
   virtual plansys2_msgs::msg::DurativeAction::SharedPtr getDurativeAction(
-    const std::string & durative_action, const std::vector<std::string> & params) =
+    const std::string & durative_action, const std::vector<std::string> & params, const std::vector<plansys2_msgs::msg::Param>& instances) =
   0;
 
   /// Get the current domain, ready to be saved to file, or to initialize another domain.

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -250,7 +250,7 @@ DomainExpert::getDurativeActions()
 }
 
 plansys2_msgs::msg::DurativeAction::SharedPtr
-DomainExpert::getDurativeAction(const std::string & action, const std::vector<std::string> & params)
+DomainExpert::getDurativeAction(const std::string &action, const std::vector<std::string> &params, const std::vector<plansys2_msgs::msg::Param> &instances)
 {
   std::string action_search = action;
   std::transform(

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -283,20 +283,24 @@ DomainExpert::getDurativeAction(const std::string &action, const std::vector<std
         domain_->types[action_obj->params[j]]->getSubTypesNames(param.sub_types);
         ret->parameters.push_back(param);
       }
-
+      // Instances
+      std::map<std::string, std::vector<std::string>> instances_map;
+      for (const auto & instance : instances) {
+        instances_map[instance.type].push_back(instance.name);
+      }
       // Preconditions AtStart
       if (action_obj->pre) {
-        action_obj->pre->getTree(ret->at_start_requirements, *domain_, params);
+        action_obj->pre->getTree(ret->at_start_requirements, *domain_, params, instances_map);
       }
 
       // Preconditions OverAll
       if (action_obj->pre_o) {
-        action_obj->pre_o->getTree(ret->over_all_requirements, *domain_, params);
+        action_obj->pre_o->getTree(ret->over_all_requirements, *domain_, params, instances_map);
       }
 
       // Preconditions AtEnd
       if (action_obj->pre_e) {
-        action_obj->pre_e->getTree(ret->at_end_requirements, *domain_, params);
+        action_obj->pre_e->getTree(ret->at_end_requirements, *domain_, params, instances_map);
       }
 
       // Effects AtStart

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -250,7 +250,9 @@ DomainExpert::getDurativeActions()
 }
 
 plansys2_msgs::msg::DurativeAction::SharedPtr
-DomainExpert::getDurativeAction(const std::string &action, const std::vector<std::string> &params, const std::vector<plansys2_msgs::msg::Param> &instances)
+DomainExpert::getDurativeAction(
+  const std::string & action, const std::vector<std::string> & params,
+  const std::vector<plansys2_msgs::msg::Param> & instances)
 {
   std::string action_search = action;
   std::transform(

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -181,7 +181,8 @@ DomainExpert::getActions()
 }
 
 plansys2_msgs::msg::Action::SharedPtr
-DomainExpert::getAction(const std::string & action, const std::vector<std::string> & params)
+DomainExpert::getAction(const std::string & action, const std::vector<std::string> & params,
+  const std::vector<plansys2_msgs::msg::Param> & instances)
 {
   std::string action_search = action;
   std::transform(
@@ -191,7 +192,10 @@ DomainExpert::getAction(const std::string & action, const std::vector<std::strin
   auto ret = std::make_shared<plansys2_msgs::msg::Action>();
   bool found = false;
   unsigned i = 0;
-
+  std::map<std::string, std::vector<std::string>> instances_map;
+  for (const auto & instance : instances) {
+    instances_map[instance.type].push_back(instance.name);
+  }
   while (i < domain_->actions.size() && !found) {
     bool is_action = dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]) == nullptr;
     parser::pddl::Action * action_obj = dynamic_cast<parser::pddl::Action *>(domain_->actions[i]);
@@ -215,12 +219,12 @@ DomainExpert::getAction(const std::string & action, const std::vector<std::strin
 
       // Preconditions
       if (action_obj->pre) {
-        action_obj->pre->getTree(ret->preconditions, *domain_, params);
+        action_obj->pre->getTree(ret->preconditions, *domain_, params, instances_map);
       }
 
       // Effects
       if (action_obj->eff) {
-        action_obj->eff->getTree(ret->effects, *domain_, params);
+        action_obj->eff->getTree(ret->effects, *domain_, params, instances_map);
       }
     }
     i++;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -408,8 +408,9 @@ DomainExpertClient::getDurativeActions()
 
 plansys2_msgs::msg::DurativeAction::SharedPtr
 DomainExpertClient::getDurativeAction(
-  const std::string & action,
-  const std::vector<std::string> & params)
+    const std::string &action,
+    const std::vector<std::string> &params,
+    const std::vector<plansys2_msgs::msg::Param> &instances)
 {
   while (!get_durative_action_details_client_->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
@@ -425,6 +426,7 @@ DomainExpertClient::getDurativeAction(
 
   request->durative_action = action;
   request->parameters = params;
+  request->instances = instances;
 
   auto future_result = get_durative_action_details_client_->async_send_request(request);
 

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -408,9 +408,9 @@ DomainExpertClient::getDurativeActions()
 
 plansys2_msgs::msg::DurativeAction::SharedPtr
 DomainExpertClient::getDurativeAction(
-    const std::string &action,
-    const std::vector<std::string> &params,
-    const std::vector<plansys2_msgs::msg::Param> &instances)
+  const std::string & action,
+  const std::vector<std::string> & params,
+  const std::vector<plansys2_msgs::msg::Param> & instances)
 {
   while (!get_durative_action_details_client_->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -333,7 +333,8 @@ DomainExpertClient::getActions()
 plansys2_msgs::msg::Action::SharedPtr
 DomainExpertClient::getAction(
   const std::string & action,
-  const std::vector<std::string> & params)
+  const std::vector<std::string> & params,
+  const std::vector<plansys2_msgs::msg::Param> & instances)
 {
   while (!get_action_details_client_->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
@@ -349,6 +350,7 @@ DomainExpertClient::getAction(
 
   request->action = action;
   request->parameters = params;
+  request->instances = instances;
 
   auto future_result = get_action_details_client_->async_send_request(request);
 

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -290,7 +290,7 @@ DomainExpertNode::get_domain_durative_action_details_service_callback(
 
     RCLCPP_WARN(get_logger(), "Requesting service in non-active state");
   } else {
-    auto action = domain_expert_->getDurativeAction(request->durative_action, request->parameters);
+    auto action = domain_expert_->getDurativeAction(request->durative_action, request->parameters, request->instances);
 
     if (action) {
       response->durative_action = *action;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -290,7 +290,8 @@ DomainExpertNode::get_domain_durative_action_details_service_callback(
 
     RCLCPP_WARN(get_logger(), "Requesting service in non-active state");
   } else {
-    auto action = domain_expert_->getDurativeAction(request->durative_action, request->parameters, request->instances);
+    auto action = domain_expert_->getDurativeAction(
+      request->durative_action, request->parameters, request->instances);
 
     if (action) {
       response->durative_action = *action;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -247,7 +247,7 @@ DomainExpertNode::get_domain_action_details_service_callback(
 
     RCLCPP_WARN(get_logger(), "Requesting service in non-active state");
   } else {
-    auto action = domain_expert_->getAction(request->action, request->parameters);
+    auto action = domain_expert_->getAction(request->action, request->parameters, request->instances);
 
     if (action) {
       response->action = *action;

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -134,9 +134,8 @@ protected:
   std::list<GraphNode::Ptr> get_final_nodes(
     const std::list<GraphNode::Ptr> &nodes) const;
   std::list<GraphNode::Ptr> get_final_nodes(
-    const GraphNode::Ptr &current_node,
-    const std::vector<plansys2_msgs::msg::Tree> &requirements,
-    const std::list<GraphNode::Ptr> &nodes) const;
+    const std::list<GraphNode::Ptr> &nodes,
+    const std::vector<plansys2_msgs::msg::Tree> &requirements) const;
 
   std::string get_flow_tree(
     GraphNode::Ptr node,

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -137,6 +137,11 @@ protected:
   std::list<GraphNode::Ptr> get_final_nodes(const std::list<GraphNode::Ptr> &nodes) const;
   std::vector<plansys2_msgs::msg::Tree> split_requirements(const std::vector<plansys2_msgs::msg::Tree>
                                                                &requirements) const;
+  std::list<GraphNode::Ptr> get_contradict_finals(
+    const GraphNode::Ptr & current,
+    const std::list<GraphNode::Ptr> & nodes,
+    const std::vector<plansys2::Predicate> & predicates,
+    const std::vector<plansys2::Function> & functions) const;
 
   std::string get_flow_tree(
     GraphNode::Ptr node,

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -132,10 +132,10 @@ protected:
     const std::vector<plansys2::Function> & functions,
     const std::list<GraphNode::Ptr> & ret) const;
   std::list<GraphNode::Ptr> get_final_nodes(
-    const std::list<GraphNode::Ptr> &nodes) const;
-  std::list<GraphNode::Ptr> get_final_nodes(
     const std::list<GraphNode::Ptr> &nodes,
     const std::vector<plansys2_msgs::msg::Tree> &requirements) const;
+  std::vector<plansys2_msgs::msg::Tree> split_requirements(const std::vector<plansys2_msgs::msg::Tree>
+     & requirements) const;
 
   std::string get_flow_tree(
     GraphNode::Ptr node,

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -131,6 +131,12 @@ protected:
     const std::vector<plansys2::Predicate> & predicates,
     const std::vector<plansys2::Function> & functions,
     const std::list<GraphNode::Ptr> & ret) const;
+  std::list<GraphNode::Ptr> get_final_nodes(
+    const std::list<GraphNode::Ptr> &nodes) const;
+  std::list<GraphNode::Ptr> get_final_nodes(
+    const GraphNode::Ptr &current_node,
+    const std::vector<plansys2_msgs::msg::Tree> &requirements,
+    const std::list<GraphNode::Ptr> &nodes) const;
 
   std::string get_flow_tree(
     GraphNode::Ptr node,

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -131,11 +131,12 @@ protected:
     const std::vector<plansys2::Predicate> & predicates,
     const std::vector<plansys2::Function> & functions,
     const std::list<GraphNode::Ptr> & ret) const;
-  std::list<GraphNode::Ptr> get_final_nodes(
+  std::list<GraphNode::Ptr> get_parent_nodes(
     const std::list<GraphNode::Ptr> &nodes,
-    const std::vector<plansys2_msgs::msg::Tree> &requirements) const;
+    const std::vector<plansys2_msgs::msg::Tree> &requirements, const bool get_final = true) const;
+  std::list<GraphNode::Ptr> get_final_nodes(const std::list<GraphNode::Ptr> &nodes) const;
   std::vector<plansys2_msgs::msg::Tree> split_requirements(const std::vector<plansys2_msgs::msg::Tree>
-     & requirements) const;
+                                                               &requirements) const;
 
   std::string get_flow_tree(
     GraphNode::Ptr node,

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -787,7 +787,7 @@ std::vector<ActionStamped>
 BTBuilder::get_plan_actions(const plansys2_msgs::msg::Plan & plan)
 {
   std::vector<ActionStamped> ret;
-
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
   for (auto & item : plan.items) {
     ActionStamped action_stamped;
 
@@ -795,7 +795,7 @@ BTBuilder::get_plan_actions(const plansys2_msgs::msg::Plan & plan)
     action_stamped.duration = item.duration;
     action_stamped.action =
       domain_client_->getDurativeAction(
-      get_action_name(item.action), get_action_params(item.action));
+      get_action_name(item.action), get_action_params(item.action), instances);
 
     ret.push_back(action_stamped);
   }

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -406,7 +406,7 @@ BTBuilder::get_contradict_finals(
   std::list<GraphNode::Ptr> finals = get_final_nodes(nodes);
   std::list<GraphNode::Ptr> ret;
   for (const auto & node : finals) {
-    if(is_parallelizable(current->action, predicates, functions, {node}))
+    if(!is_parallelizable(current->action, predicates, functions, {node}))
       ret.push_back(node);
   }
   return ret;
@@ -511,7 +511,7 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     if (!requirements.empty() && new_node->in_arcs.empty()) {
       std::vector<plansys2_msgs::msg::Tree> split_reqs = split_requirements(requirements);
       std::list<GraphNode::Ptr> parents = get_parent_nodes(graph->roots, split_reqs, false);
-      parents.splice(parents.end(), get_final_nodes(parents));
+      parents.splice(parents.end(), get_contradict_finals(new_node, graph->roots, predicates, functions));
       for (const auto parent : parents) {
         prune_backwards(new_node, parent);
 

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -314,39 +314,84 @@ std::vector<plansys2_msgs::msg::Tree> BTBuilder::split_requirements(
   return ret;
 }
 
+std::list<GraphNode::Ptr> BTBuilder::get_final_nodes(
+  const std::list<GraphNode::Ptr> & nodes) const
+{
+  std::list<GraphNode::Ptr> ret;
+  for (const auto & node : nodes) {
+    if (node->out_arcs.empty()) {
+      ret.push_back(node);
+    } else {
+      ret.splice(ret.end(), get_final_nodes(node->out_arcs));
+    }
+  }
+  return ret;
+}
+
 std::list<GraphNode::Ptr>
-BTBuilder::get_final_nodes(
+BTBuilder::get_parent_nodes(
   const std::list<GraphNode::Ptr> & nodes,
-  const std::vector<plansys2_msgs::msg::Tree> &requirements) const
+  const std::vector<plansys2_msgs::msg::Tree> &requirements, const bool get_final) const
 {
   std::list<GraphNode::Ptr> ret(nodes);
-  auto it = nodes.begin();
-  while (it != nodes.end()){
+  auto node_it = nodes.begin();
+  while (node_it != nodes.end()){
     bool has_effect = false;
     std::vector<uint32_t> skip_ids;
-    auto node = *it;
+    auto node = *node_it;
     for (const auto &tree : requirements) {
       if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
         continue;
-      std::vector<plansys2::Predicate> predicates = (*it)->predicates;
-      std::vector<plansys2::Function> functions = (*it)->functions;
+      std::vector<plansys2::Predicate> predicates = (*node_it)->predicates;
+      std::vector<plansys2::Function> functions = (*node_it)->functions;
       if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
         skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
       bool before = check(tree, predicates, functions);
-      apply((*it)->action.action->at_start_effects, predicates, functions);
-      apply((*it)->action.action->at_end_effects, predicates, functions);
+      apply((*node_it)->action.action->at_start_effects, predicates, functions);
+      apply((*node_it)->action.action->at_end_effects, predicates, functions);
       bool after = check(tree, predicates, functions);
       if (after && !before) {
         has_effect = true;
         break;
       }
     }
-    auto rec_ret = get_final_nodes((*it)->out_arcs, requirements);
+    auto rec_ret = get_parent_nodes((*node_it)->out_arcs, requirements, false);
     if (!has_effect || !rec_ret.empty())
-      ret.remove(*it);
+      ret.remove(*node_it);
     if (!rec_ret.empty())
       ret.splice(ret.end(), rec_ret);
-    ++it;
+    ++node_it;
+  }
+  if (get_final) {
+    auto finals = get_final_nodes(nodes);
+    auto it = ret.begin();
+    while (it != ret.end()) {
+      bool has_effect = false;
+      std::vector<uint32_t> skip_ids;
+      auto node = *it;
+      for (const auto &tree : requirements) {
+        if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
+          continue;
+        std::vector<plansys2::Predicate> predicates = (*it)->predicates;
+        std::vector<plansys2::Function> functions = (*it)->functions;
+        if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
+          skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
+        bool before = check(tree, predicates, functions);
+        apply((*it)->action.action->at_start_effects, predicates, functions);
+        apply((*it)->action.action->at_end_effects, predicates, functions);
+        bool after = check(tree, predicates, functions);
+        if (after && !before) {
+          has_effect = true;
+          break;
+        }
+      }
+      if (!has_effect) {
+        it = finals.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    ret.splice(ret.end(), finals);
   }
 
   return ret;
@@ -446,6 +491,36 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
       }
     }
 
+    // If requirements still left and no parent node found, check if 
+    // they are satisfied by multiple nodes
+    if (!requirements.empty() && new_node->in_arcs.empty()) {
+      std::vector<plansys2_msgs::msg::Tree> split_reqs = split_requirements(requirements);
+      std::list<GraphNode::Ptr> parents = get_parent_nodes(graph->roots, split_reqs);
+      for (const auto parent : parents) {
+        prune_backwards(new_node, parent);
+
+        // Create the connections to the parent node
+        if (std::find(new_node->in_arcs.begin(), new_node->in_arcs.end(), parent) ==
+          new_node->in_arcs.end())
+        {
+          new_node->in_arcs.push_back(parent);
+        }
+        if (std::find(parent->out_arcs.begin(), parent->out_arcs.end(), new_node) ==
+          parent->out_arcs.end())
+        {
+          parent->out_arcs.push_back(new_node);
+        }
+      }
+      // std::list<GraphNode::Ptr> used_nodes;
+      // predicates = problem_client_->getPredicates();
+      // functions = problem_client_->getFunctions();
+      // get_state(new_node, used_nodes, predicates, functions);
+      // new_node->predicates = predicates;
+      // new_node->functions = functions;
+
+      // remove_existing_requirements(requirements, predicates, functions);
+    } 
+
     // Look for contradicting parallel actions
     // A1 and A2 cannot run in parallel if the effects of A1 contradict the requirements of A2
     auto contradictions = get_node_contradict(graph, new_node);
@@ -478,35 +553,6 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     // These should be satisfied by the initial state.
     remove_existing_requirements(requirements, predicates, functions);
 
-    // If requirements still left and no parent node found, check if 
-    // they are satisfied by multiple nodes
-    if (!requirements.empty() && new_node->in_arcs.empty()) {
-      std::vector<plansys2_msgs::msg::Tree> split_reqs = split_requirements(requirements);
-      std::list<GraphNode::Ptr> parents = get_final_nodes(graph->roots, split_reqs);
-      for (const auto parent : parents) {
-        prune_backwards(new_node, parent);
-
-        // Create the connections to the parent node
-        if (std::find(new_node->in_arcs.begin(), new_node->in_arcs.end(), parent) ==
-          new_node->in_arcs.end())
-        {
-          new_node->in_arcs.push_back(parent);
-        }
-        if (std::find(parent->out_arcs.begin(), parent->out_arcs.end(), new_node) ==
-          parent->out_arcs.end())
-        {
-          parent->out_arcs.push_back(new_node);
-        }
-      }
-      used_nodes.clear();
-      predicates = problem_client_->getPredicates();
-      functions = problem_client_->getFunctions();
-      get_state(new_node, used_nodes, predicates, functions);
-      new_node->predicates = predicates;
-      new_node->functions = functions;
-
-      remove_existing_requirements(requirements, predicates, functions);
-    } 
     for (const auto & req : requirements) {
       std::cerr << "[ERROR] requirement not met: [" <<
         parser::pddl::toString(req) << "]" << std::endl;

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -293,19 +293,19 @@ BTBuilder::prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & use
 
 std::list<GraphNode::Ptr>
 BTBuilder::get_final_nodes(
-  const GraphNode::Ptr & current_node,
-  const std::vector<plansys2_msgs::msg::Tree> &requirements,
-  const std::list<GraphNode::Ptr> & nodes) const
+  const std::list<GraphNode::Ptr> & nodes,
+  const std::vector<plansys2_msgs::msg::Tree> &requirements) const
 {
   std::list<GraphNode::Ptr> ret;
   for (const auto & node : nodes) {
-    if (node == current_node) {
+    if (node->out_arcs.empty()) {
       ret.push_back(node);
     } else {
       ret.splice(ret.end(), get_final_nodes(node->out_arcs));
     }
   }
   std::vector<plansys2_msgs::msg::Tree> all_reqs;
+  // Turn concurrent, each thread handles one of three requirements. Handle case with less.
   all_reqs.reserve(requirements[0].nodes.size());
   for (const auto & tree : requirements) {
     for (const auto & node : tree.nodes) {
@@ -331,14 +331,13 @@ BTBuilder::get_final_nodes(
       for (const auto &tree : all_reqs) {
         if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
           continue;
-        auto node = *it;
-        std::vector<plansys2::Predicate> predicates = node->predicates;
-        std::vector<plansys2::Function> functions = node->functions;
+        std::vector<plansys2::Predicate> predicates = (*it)->predicates;
+        std::vector<plansys2::Function> functions = (*it)->functions;
         if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
           skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
         bool before = check(tree, predicates, functions);
-        apply(node->action.action->at_start_effects, predicates, functions);
-        apply(node->action.action->at_end_effects, predicates, functions);
+        apply((*it)->action.action->at_start_effects, predicates, functions);
+        apply((*it)->action.action->at_end_effects, predicates, functions);
         bool after = check(tree, predicates, functions);
         if (after && !before) {
           ++it;
@@ -495,7 +494,7 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     // If requirements still left and no parent node found, check if 
     // they are satisfied by multiple nodes
     if (!requirements.empty() && new_node->in_arcs.empty()) {
-      std::list<GraphNode::Ptr> parents = get_final_nodes(new_node, requirements, graph->roots);
+      std::list<GraphNode::Ptr> parents = get_final_nodes(graph->roots, requirements);
       for (const auto parent : parents) {
         prune_backwards(new_node, parent);
 

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -291,6 +291,81 @@ BTBuilder::prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & use
   }
 }
 
+std::list<GraphNode::Ptr>
+BTBuilder::get_final_nodes(
+  const GraphNode::Ptr & current_node,
+  const std::vector<plansys2_msgs::msg::Tree> &requirements,
+  const std::list<GraphNode::Ptr> & nodes) const
+{
+  std::list<GraphNode::Ptr> ret;
+  for (const auto & node : nodes) {
+    if (node == current_node) {
+      ret.push_back(node);
+    } else {
+      ret.splice(ret.end(), get_final_nodes(node->out_arcs));
+    }
+  }
+  std::vector<plansys2_msgs::msg::Tree> all_reqs;
+  all_reqs.reserve(requirements[0].nodes.size());
+  for (const auto & tree : requirements) {
+    for (const auto & node : tree.nodes) {
+      if (node.node_type == plansys2_msgs::msg::Node::FORALL ||
+          node.node_type == plansys2_msgs::msg::Node::AND)
+        continue;
+      plansys2_msgs::msg::Tree node_tree;
+      node_tree.nodes.push_back(node);
+      if (node.node_type == plansys2_msgs::msg::Node::IMPLY) {
+        node_tree.nodes.resize(node.children.at(node.children.size() - 1) + 1);
+        for (const auto & child : node.children) {
+          node_tree.nodes[child] = tree.nodes[child];
+        }
+      }
+      all_reqs.push_back(node_tree);
+    }
+  }
+
+  auto it = ret.begin();
+  while (it != ret.end()){
+    bool has_effect = true;
+    std::vector<uint32_t> skip_ids;
+      for (const auto &tree : all_reqs) {
+        if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
+          continue;
+        auto node = *it;
+        std::vector<plansys2::Predicate> predicates = node->predicates;
+        std::vector<plansys2::Function> functions = node->functions;
+        if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
+          skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
+        bool before = check(tree, predicates, functions);
+        apply(node->action.action->at_start_effects, predicates, functions);
+        apply(node->action.action->at_end_effects, predicates, functions);
+        bool after = check(tree, predicates, functions);
+        if (after && !before) {
+          ++it;
+          has_effect = true;
+          break;
+        }
+      }
+    if (!has_effect)
+      it = ret.erase(it);
+  }
+  return ret;
+}
+
+std::list<GraphNode::Ptr>
+BTBuilder::get_final_nodes(const std::list<GraphNode::Ptr> & nodes) const
+{
+  std::list<GraphNode::Ptr> ret;
+  for (const auto & node : nodes) {
+    if (node->out_arcs.empty()) {
+      ret.push_back(node);
+    } else {
+      ret.splice(ret.end(), get_final_nodes(node->out_arcs));
+    }
+  }
+  return ret;
+}
+
 void
 BTBuilder::get_state(
   const GraphNode::Ptr & node,
@@ -416,6 +491,35 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     // Check any requirements that do not have satisfying nodes.
     // These should be satisfied by the initial state.
     remove_existing_requirements(requirements, predicates, functions);
+
+    // If requirements still left and no parent node found, check if 
+    // they are satisfied by multiple nodes
+    if (!requirements.empty() && new_node->in_arcs.empty()) {
+      std::list<GraphNode::Ptr> parents = get_final_nodes(new_node, requirements, graph->roots);
+      for (const auto parent : parents) {
+        prune_backwards(new_node, parent);
+
+        // Create the connections to the parent node
+        if (std::find(new_node->in_arcs.begin(), new_node->in_arcs.end(), parent) ==
+          new_node->in_arcs.end())
+        {
+          new_node->in_arcs.push_back(parent);
+        }
+        if (std::find(parent->out_arcs.begin(), parent->out_arcs.end(), new_node) ==
+          parent->out_arcs.end())
+        {
+          parent->out_arcs.push_back(new_node);
+        }
+      }
+      used_nodes.clear();
+      predicates = problem_client_->getPredicates();
+      functions = problem_client_->getFunctions();
+      get_state(new_node, used_nodes, predicates, functions);
+      new_node->predicates = predicates;
+      new_node->functions = functions;
+
+      remove_existing_requirements(requirements, predicates, functions);
+    } 
     for (const auto & req : requirements) {
       std::cerr << "[ERROR] requirement not met: [" <<
         parser::pddl::toString(req) << "]" << std::endl;

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -787,7 +787,8 @@ std::vector<ActionStamped>
 BTBuilder::get_plan_actions(const plansys2_msgs::msg::Plan & plan)
 {
   std::vector<ActionStamped> ret;
-  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(
+    problem_client_->getInstances());
   for (auto & item : plan.items) {
     ActionStamped action_stamped;
 

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -291,22 +291,10 @@ BTBuilder::prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & use
   }
 }
 
-std::list<GraphNode::Ptr>
-BTBuilder::get_final_nodes(
-  const std::list<GraphNode::Ptr> & nodes,
-  const std::vector<plansys2_msgs::msg::Tree> &requirements) const
+std::vector<plansys2_msgs::msg::Tree> BTBuilder::split_requirements(
+  const std::vector<plansys2_msgs::msg::Tree> & requirements) const
 {
-  std::list<GraphNode::Ptr> ret;
-  for (const auto & node : nodes) {
-    if (node->out_arcs.empty()) {
-      ret.push_back(node);
-    } else {
-      ret.splice(ret.end(), get_final_nodes(node->out_arcs));
-    }
-  }
-  std::vector<plansys2_msgs::msg::Tree> all_reqs;
-  // Turn concurrent, each thread handles one of three requirements. Handle case with less.
-  all_reqs.reserve(requirements[0].nodes.size());
+  std::vector<plansys2_msgs::msg::Tree> ret;
   for (const auto & tree : requirements) {
     for (const auto & node : tree.nodes) {
       if (node.node_type == plansys2_msgs::msg::Node::FORALL ||
@@ -320,48 +308,47 @@ BTBuilder::get_final_nodes(
           node_tree.nodes[child] = tree.nodes[child];
         }
       }
-      all_reqs.push_back(node_tree);
+      ret.push_back(node_tree);
     }
-  }
-
-  auto it = ret.begin();
-  while (it != ret.end()){
-    bool has_effect = true;
-    std::vector<uint32_t> skip_ids;
-      for (const auto &tree : all_reqs) {
-        if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
-          continue;
-        std::vector<plansys2::Predicate> predicates = (*it)->predicates;
-        std::vector<plansys2::Function> functions = (*it)->functions;
-        if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
-          skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
-        bool before = check(tree, predicates, functions);
-        apply((*it)->action.action->at_start_effects, predicates, functions);
-        apply((*it)->action.action->at_end_effects, predicates, functions);
-        bool after = check(tree, predicates, functions);
-        if (after && !before) {
-          ++it;
-          has_effect = true;
-          break;
-        }
-      }
-    if (!has_effect)
-      it = ret.erase(it);
   }
   return ret;
 }
 
 std::list<GraphNode::Ptr>
-BTBuilder::get_final_nodes(const std::list<GraphNode::Ptr> & nodes) const
+BTBuilder::get_final_nodes(
+  const std::list<GraphNode::Ptr> & nodes,
+  const std::vector<plansys2_msgs::msg::Tree> &requirements) const
 {
-  std::list<GraphNode::Ptr> ret;
-  for (const auto & node : nodes) {
-    if (node->out_arcs.empty()) {
-      ret.push_back(node);
-    } else {
-      ret.splice(ret.end(), get_final_nodes(node->out_arcs));
+  std::list<GraphNode::Ptr> ret(nodes);
+  auto it = nodes.begin();
+  while (it != nodes.end()){
+    bool has_effect = false;
+    std::vector<uint32_t> skip_ids;
+    auto node = *it;
+    for (const auto &tree : requirements) {
+      if(std::find(skip_ids.begin(), skip_ids.end(), tree.nodes[0].node_id) != skip_ids.end())
+        continue;
+      std::vector<plansys2::Predicate> predicates = (*it)->predicates;
+      std::vector<plansys2::Function> functions = (*it)->functions;
+      if (tree.nodes[0].node_type == plansys2_msgs::msg::Node::IMPLY)
+        skip_ids.insert(skip_ids.end(), tree.nodes[0].children.begin(), tree.nodes[0].children.end());
+      bool before = check(tree, predicates, functions);
+      apply((*it)->action.action->at_start_effects, predicates, functions);
+      apply((*it)->action.action->at_end_effects, predicates, functions);
+      bool after = check(tree, predicates, functions);
+      if (after && !before) {
+        has_effect = true;
+        break;
+      }
     }
+    auto rec_ret = get_final_nodes((*it)->out_arcs, requirements);
+    if (!has_effect || !rec_ret.empty())
+      ret.remove(*it);
+    if (!rec_ret.empty())
+      ret.splice(ret.end(), rec_ret);
+    ++it;
   }
+
   return ret;
 }
 
@@ -494,7 +481,8 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     // If requirements still left and no parent node found, check if 
     // they are satisfied by multiple nodes
     if (!requirements.empty() && new_node->in_arcs.empty()) {
-      std::list<GraphNode::Ptr> parents = get_final_nodes(graph->roots, requirements);
+      std::vector<plansys2_msgs::msg::Tree> split_reqs = split_requirements(requirements);
+      std::list<GraphNode::Ptr> parents = get_final_nodes(graph->roots, split_reqs);
       for (const auto parent : parents) {
         prune_backwards(new_node, parent);
 

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -397,6 +397,21 @@ BTBuilder::get_parent_nodes(
   return ret;
 }
 
+std::list<GraphNode::Ptr> 
+BTBuilder::get_contradict_finals(
+  const GraphNode::Ptr &current, const std::list<GraphNode::Ptr> &nodes,
+  const std::vector<plansys2::Predicate> &predicates,
+  const std::vector<plansys2::Function> &functions) const
+{
+  std::list<GraphNode::Ptr> finals = get_final_nodes(nodes);
+  std::list<GraphNode::Ptr> ret;
+  for (const auto & node : finals) {
+    if(is_parallelizable(current->action, predicates, functions, {node}))
+      ret.push_back(node);
+  }
+  return ret;
+}
+
 void
 BTBuilder::get_state(
   const GraphNode::Ptr & node,
@@ -495,7 +510,8 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     // they are satisfied by multiple nodes
     if (!requirements.empty() && new_node->in_arcs.empty()) {
       std::vector<plansys2_msgs::msg::Tree> split_reqs = split_requirements(requirements);
-      std::list<GraphNode::Ptr> parents = get_parent_nodes(graph->roots, split_reqs);
+      std::list<GraphNode::Ptr> parents = get_parent_nodes(graph->roots, split_reqs, false);
+      parents.splice(parents.end(), get_final_nodes(parents));
       for (const auto parent : parents) {
         prune_backwards(new_node, parent);
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -70,6 +70,7 @@ ExecutorClient::start_plan_execution(const plansys2_msgs::msg::Plan & plan)
 
     if (success) {
       executing_plan_ = true;
+      feedback_ = ExecutePlan::Feedback();
       return true;
     }
   } else {

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -227,7 +227,8 @@ ExecutorNode::getOrderedSubGoals()
   auto goal = problem_client_->getGoal();
   auto local_predicates = problem_client_->getPredicates();
   auto local_functions = problem_client_->getFunctions();
-  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(
+    problem_client_->getInstances());
 
   std::vector<plansys2_msgs::msg::Tree> ordered_goals;
   std::vector<uint32_t> unordered_subgoals = parser::pddl::getSubtreeIds(goal);
@@ -329,9 +330,9 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   auto action_map = std::make_shared<std::map<std::string, ActionExecutionInfo>>();
   auto action_timeout_actions = this->get_parameter("action_timeouts.actions").as_string_array();
-  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
-  for (const auto &plan_item : current_plan_.value().items)
-  {
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(
+    problem_client_->getInstances());
+  for (const auto & plan_item : current_plan_.value().items) {
     auto index = plan_item.action + ":" + std::to_string(static_cast<int>(plan_item.time * 1000));
 
     (*action_map)[index] = ActionExecutionInfo();

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -328,8 +328,9 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   auto action_map = std::make_shared<std::map<std::string, ActionExecutionInfo>>();
   auto action_timeout_actions = this->get_parameter("action_timeouts.actions").as_string_array();
-
-  for (const auto & plan_item : current_plan_.value().items) {
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
+  for (const auto &plan_item : current_plan_.value().items)
+  {
     auto index = plan_item.action + ":" + std::to_string(static_cast<int>(plan_item.time * 1000));
 
     (*action_map)[index] = ActionExecutionInfo();
@@ -337,7 +338,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
       ActionExecutor::make_shared(plan_item.action, shared_from_this());
     (*action_map)[index].durative_action_info =
       domain_client_->getDurativeAction(
-      get_action_name(plan_item.action), get_action_params(plan_item.action));
+      get_action_name(plan_item.action), get_action_params(plan_item.action), instances);
 
     (*action_map)[index].duration = plan_item.duration;
     std::string action_name = (*action_map)[index].durative_action_info->name;

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -227,6 +227,7 @@ ExecutorNode::getOrderedSubGoals()
   auto goal = problem_client_->getGoal();
   auto local_predicates = problem_client_->getPredicates();
   auto local_functions = problem_client_->getFunctions();
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(problem_client_->getInstances());
 
   std::vector<plansys2_msgs::msg::Tree> ordered_goals;
   std::vector<uint32_t> unordered_subgoals = parser::pddl::getSubtreeIds(goal);
@@ -246,7 +247,7 @@ ExecutorNode::getOrderedSubGoals()
   for (const auto & plan_item : current_plan_.value().items) {
     std::shared_ptr<plansys2_msgs::msg::DurativeAction> action =
       domain_client_->getDurativeAction(
-      get_action_name(plan_item.action), get_action_params(plan_item.action));
+      get_action_name(plan_item.action), get_action_params(plan_item.action), instances);
     apply(action->at_start_effects, local_predicates, local_functions);
     apply(action->at_end_effects, local_predicates, local_functions);
 

--- a/plansys2_executor/test/pddl/test_forall_imply.pddl
+++ b/plansys2_executor/test/pddl/test_forall_imply.pddl
@@ -1,0 +1,27 @@
+(define (domain test_forall_imply)
+  (:requirements :strips :adl :typing :durative-actions :fluents)
+  (:types
+    object
+    item - object
+    location - object
+  )
+  (:predicates
+    (item_at ?item - item ?location - location)
+    (item_checked ?item - item)
+    (all_items_checked ?location - location)
+  )
+  (:durative-action check_items
+    :parameters (?location - location)
+    :duration (= ?duration 1)
+    :condition
+      (and (over all 
+        (forall (?item - item)
+          (imply (item_at ?item ?location) (item_checked ?item))
+        )
+      ))
+    :effect
+      (and
+        (at end (all_items_checked ?location))
+      )
+  )
+)

--- a/plansys2_executor/test/unit/bt_node_test.cpp
+++ b/plansys2_executor/test/unit/bt_node_test.cpp
@@ -639,6 +639,117 @@ TEST(problem_expert, at_end_effect_test)
   t.join();
 }
 
+TEST(problem_expert, forall_imply_test)
+{
+  auto test_node = rclcpp::Node::make_shared("test_node");
+  auto test_lc_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lc_node");
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+
+  auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/test_forall_imply.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/test_forall_imply.pddl"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 8);
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance("location1", "location")));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance("item1", "item")));
+  ASSERT_TRUE(problem_client->addInstance(plansys2::Instance("item2", "item")));
+
+  auto instances = plansys2::convertVector<plansys2_msgs::msg::Param, plansys2::Instance>(
+    problem_client->getInstances());
+  auto action_map = std::make_shared<std::map<std::string, plansys2::ActionExecutionInfo>>();
+  (*action_map)["(check_items location1):1"] = plansys2::ActionExecutionInfo();
+  (*action_map)["(check_items location1):1"].durative_action_info =
+    domain_client->getDurativeAction(
+    plansys2::get_action_name("(check_items location1)"),
+    plansys2::get_action_params("(check_items location1)"), instances);
+
+  ASSERT_NE(
+    (*action_map)["(check_items location1):1"].durative_action_info,
+    nullptr);
+
+  std::string bt_xml_tree =
+    R"(
+    <root main_tree_to_execute = "MainTree" >
+      <BehaviorTree ID="MainTree">
+        <Sequence name="root_sequence">
+          <CheckOverAllReq action="(check_items location1):1"/>
+       </Sequence>
+      </BehaviorTree>
+    </root>
+  )";
+
+  auto blackboard = BT::Blackboard::create();
+
+  blackboard->set("action_map", action_map);
+  blackboard->set("node", test_lc_node);
+  blackboard->set("problem_client", problem_client);
+
+  BT::BehaviorTreeFactory factory;
+  factory.registerNodeType<plansys2::ExecuteAction>("ExecuteAction");
+  factory.registerNodeType<plansys2::CheckOverAllReq>("CheckOverAllReq");
+
+
+  std::vector<std::string> predicates = {
+    "(item_at item1 location1)",
+    "(item_at item2 location1)",
+    "(item_checked item1)",
+    "(item_checked item2)"
+  };
+
+  try {
+    for (const auto & pred : predicates) {
+      ASSERT_TRUE(problem_client->addPredicate(plansys2::Predicate(pred)));
+    }
+
+    auto tree = factory.createTreeFromText(bt_xml_tree, blackboard);
+
+    auto status = BT::NodeStatus::RUNNING;
+    status = tree.tickRoot();
+    ASSERT_EQ(status, BT::NodeStatus::SUCCESS);
+  } catch (std::exception & e) {
+    std::cerr << e.what() << std::endl;
+  }
+
+  finish = true;
+  t.join();
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/plansys2_msgs/msg/Node.msg
+++ b/plansys2_msgs/msg/Node.msg
@@ -11,6 +11,8 @@ uint8 FUNCTION = 6
 uint8 EXPRESSION = 7
 uint8 FUNCTION_MODIFIER = 8
 uint8 NUMBER = 9
+uint8 FORALL = 10
+uint8 IMPLY = 11
 
 # Expression types
 uint8 COMP_EQ = 10

--- a/plansys2_msgs/srv/GetDomainActionDetails.srv
+++ b/plansys2_msgs/srv/GetDomainActionDetails.srv
@@ -1,5 +1,6 @@
 string action
 string[] parameters
+plansys2_msgs/Param[] instances
 ---
 plansys2_msgs/Action action
 bool success

--- a/plansys2_msgs/srv/GetDomainDurativeActionDetails.srv
+++ b/plansys2_msgs/srv/GetDomainDurativeActionDetails.srv
@@ -1,5 +1,6 @@
 string durative_action
 string[] parameters
+plansys2_msgs/Param[] instances
 ---
 bool success
 plansys2_msgs/DurativeAction durative_action

--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PDDL-PARSER-SOURCES
   src/plansys2_pddl_parser/Ground.cpp
   src/plansys2_pddl_parser/Utils.cpp
   src/plansys2_pddl_parser/TypeGround.cpp
+  src/plansys2_pddl_parser/Imply.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${PDDL-PARSER-SOURCES})

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Action.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Action.h
@@ -43,7 +43,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parseConditions( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/And.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/And.h
@@ -32,7 +32,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Condition.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Condition.h
@@ -28,7 +28,7 @@ public:
 
 	virtual void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const = 0;
 
-	virtual plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const = 0;
+	virtual plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {}) const = 0;
 
 	virtual void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) = 0;
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Derived.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Derived.h
@@ -31,7 +31,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Domain.h
@@ -9,6 +9,7 @@
   #include "plansys2_pddl_parser/Forall.h"
   #include "plansys2_pddl_parser/Function.h"
   #include "plansys2_pddl_parser/GroundFunc.h"
+  #include "plansys2_pddl_parser/Imply.h"
   #include "plansys2_pddl_parser/FunctionModifier.h"
 
   #include "plansys2_pddl_parser/Not.h"
@@ -603,6 +604,7 @@ public:
 		if ( s == "and" ) return new And;
 		if ( s == "exists" ) return new Exists;
 		if ( s == "forall" ) return new Forall;
+		if ( s == "imply" ) return new Imply;
 		if ( s == "assign" ) return new Assign;
 		if ( s == "increase" ) return new Increase;
 		if ( s == "decrease" ) return new Decrease;

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Exists.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Exists.h
@@ -33,7 +33,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Expression.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Expression.h
@@ -71,7 +71,7 @@ public:
 		s << " )";
 	}
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
 		node->node_type = plansys2_msgs::msg::Node::EXPRESSION;
 		node->expression_type = getExprType(op);
@@ -146,7 +146,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	double evaluate() { return 1; }
 
@@ -179,7 +179,7 @@ public:
 		s << value;
 	}
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
 		node->node_type = plansys2_msgs::msg::Node::NUMBER;
 		node->node_id = tree.nodes.size();
@@ -209,7 +209,7 @@ class DurationExpression : public Expression {
 		s << "?duration";
 	}
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		throw UnsupportedConstruct("DurationExpression");
 	}
 
@@ -253,7 +253,7 @@ public:
 		s << ts[param];
 	}
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		throw UnsupportedConstruct("ParamExpression");
 	}
 
@@ -288,7 +288,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		throw UnsupportedConstruct("ConstExpression");
 	}
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Forall.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Forall.h
@@ -32,7 +32,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Function.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Function.h
@@ -25,7 +25,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 	

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/FunctionModifier.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/FunctionModifier.h
@@ -41,7 +41,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Ground.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Ground.h
@@ -27,7 +27,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/GroundFunc.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/GroundFunc.h
@@ -23,7 +23,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void print( std::ostream & stream ) const {
 		stream << name << params << value << "\n";

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
@@ -1,0 +1,49 @@
+
+#pragma once
+
+#include "plansys2_msgs/msg/node.hpp"
+#include "plansys2_msgs/msg/tree.hpp"
+
+#include "plansys2_pddl_parser/ParamCond.h"
+
+namespace parser { namespace pddl {
+
+class Imply : public ParamCond {
+
+public:
+	Condition * cond;
+
+	Imply()
+		: cond( 0 ) {}
+
+	Imply( const Imply * f, Domain & d )
+		: ParamCond( f ), cond( 0 ) {
+		if ( f->cond ) cond = f->cond->copy( d );
+	}
+
+	~Imply() {
+		if ( cond ) delete cond;
+	}
+
+	void print( std::ostream & s ) const {
+		s << "Imply" << params << ":\n";
+		if ( cond ) cond->print( s );
+	}
+
+	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
+
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+
+	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
+
+	void addParams( int m, unsigned n ) {
+		cond->addParams( m, n );
+	}
+
+	Condition * copy( Domain & d ) {
+		return new Imply( this, d );
+	}
+
+};
+
+} } // namespaces

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
@@ -11,27 +11,27 @@ namespace parser { namespace pddl {
 class Imply : public ParamCond {
 
 public:
-	Condition * cond_1; // The initial condition of imply
-	Condition * cond_2; // The latter condition of imply
+	Condition * left; // The initial condition of imply
+	Condition * right; // The latter condition of imply
 
 	Imply()
-		: cond_1( 0 ), cond_2( 0 ) {}
+		: left( 0 ), right( 0 ) {}
 
 	Imply( const Imply * f, Domain & d )
-		: ParamCond( f ), cond_1( 0 ), cond_2( 0 ) {
-		if ( f->cond_1 ) cond_1 = f->cond_1->copy( d );
-		if ( f->cond_2 ) cond_2 = f->cond_2->copy( d );
+		: ParamCond( f ), left( 0 ), right( 0 ) {
+		if ( f->left ) left = f->left->copy( d );
+		if ( f->right ) right = f->right->copy( d );
 	}
 
 	~Imply() {
-		if ( cond_1 ) delete cond_1; // bc new creation
-		if ( cond_2 ) delete cond_2;
+		if ( left ) delete left; // bc new creation
+		if ( right ) delete right;
 	}
 
 	void print( std::ostream & s ) const {
 		s << "Imply" << params << ":\n";
-		if ( cond_1 ) cond_1->print( s );
-		if( cond_2 ) cond_2->print( s );
+		if ( left ) left->print( s );
+		if( right ) right->print( s );
 	}
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
@@ -41,8 +41,8 @@ public:
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 
 	void addParams( int m, unsigned n ) {
-		cond_1->addParams( m, n );
-		cond_2->addParams( m, n );
+		left->addParams( m, n );
+		right->addParams( m, n );
 	}
 
 	Condition * copy( Domain & d ) {

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
@@ -36,7 +36,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Imply.h
@@ -11,23 +11,27 @@ namespace parser { namespace pddl {
 class Imply : public ParamCond {
 
 public:
-	Condition * cond;
+	Condition * cond_1; // The initial condition of imply
+	Condition * cond_2; // The latter condition of imply
 
 	Imply()
-		: cond( 0 ) {}
+		: cond_1( 0 ), cond_2( 0 ) {}
 
 	Imply( const Imply * f, Domain & d )
-		: ParamCond( f ), cond( 0 ) {
-		if ( f->cond ) cond = f->cond->copy( d );
+		: ParamCond( f ), cond_1( 0 ), cond_2( 0 ) {
+		if ( f->cond_1 ) cond_1 = f->cond_1->copy( d );
+		if ( f->cond_2 ) cond_2 = f->cond_2->copy( d );
 	}
 
 	~Imply() {
-		if ( cond ) delete cond;
+		if ( cond_1 ) delete cond_1; // bc new creation
+		if ( cond_2 ) delete cond_2;
 	}
 
 	void print( std::ostream & s ) const {
 		s << "Imply" << params << ":\n";
-		if ( cond ) cond->print( s );
+		if ( cond_1 ) cond_1->print( s );
+		if( cond_2 ) cond_2->print( s );
 	}
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
@@ -37,7 +41,8 @@ public:
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 
 	void addParams( int m, unsigned n ) {
-		cond->addParams( m, n );
+		cond_1->addParams( m, n );
+		cond_2->addParams( m, n );
 	}
 
 	Condition * copy( Domain & d ) {

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Lifted.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Lifted.h
@@ -22,7 +22,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Not.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Not.h
@@ -36,7 +36,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Oneof.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Oneof.h
@@ -33,7 +33,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Or.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Or.h
@@ -35,7 +35,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Task.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Task.h
@@ -22,7 +22,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override {}
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override {
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override {
 		throw UnsupportedConstruct("Task");
 	}
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/TemporalAction.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/TemporalAction.h
@@ -52,7 +52,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parseCondition( Stringreader & f, TokenStruct< std::string > & ts, Domain & d, And * a );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/TypeGround.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/TypeGround.h
@@ -23,7 +23,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void insert( Domain & d, const StringVec & v );
 

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/When.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/When.h
@@ -36,7 +36,7 @@ public:
 
 	void PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const override;
 
-	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
+	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {}, const std::map<std::string, std::vector<std::string>> & instances_map = {} ) const override;
 
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Action.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Action.cpp
@@ -25,19 +25,19 @@ void Action::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 	s << ")\n";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Action::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Action::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     node->node_type = plansys2_msgs::msg::Node::ACTION;
     node->node_id = tree.nodes.size();
     tree.nodes.push_back(*node);
 
     if (pre) {
-        plansys2_msgs::msg::Node::SharedPtr child = pre->getTree(tree, d, replace);
+        plansys2_msgs::msg::Node::SharedPtr child = pre->getTree(tree, d, replace, instances_map);
         tree.nodes[node->node_id].children.push_back(child->node_id);
     }
 
     if (eff) {
-        plansys2_msgs::msg::Node::SharedPtr child = eff->getTree(tree, d, replace);
+        plansys2_msgs::msg::Node::SharedPtr child = eff->getTree(tree, d, replace, instances_map);
         tree.nodes[node->node_id].children.push_back(child->node_id);
     }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/And.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/And.cpp
@@ -14,14 +14,14 @@ void And::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr And::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr And::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     node->node_type = plansys2_msgs::msg::Node::AND;
     node->node_id = tree.nodes.size();
     tree.nodes.push_back(*node);
 
     for ( unsigned i = 0; i < conds.size(); ++i) {
-        plansys2_msgs::msg::Node::SharedPtr child = conds[i]->getTree(tree, d, replace);
+        plansys2_msgs::msg::Node::SharedPtr child = conds[i]->getTree(tree, d, replace, instances_map);
         tree.nodes[node->node_id].children.push_back(child->node_id);
     }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Derived.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Derived.cpp
@@ -27,7 +27,7 @@ void Derived::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< s
 	s << "\n)\n";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Derived::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Derived::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Derived");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Exists.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Exists.cpp
@@ -22,7 +22,7 @@ void Exists::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Exists::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Exists::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Exists");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Expression.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Expression.cpp
@@ -19,7 +19,7 @@ void FunctionExpression::PDDLPrint( std::ostream & s, unsigned indent, const Tok
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr FunctionExpression::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr FunctionExpression::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     node->node_type = plansys2_msgs::msg::Node::FUNCTION;
     node->node_id = tree.nodes.size();

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Forall.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Forall.cpp
@@ -24,7 +24,29 @@ void Forall::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 }
 
 plansys2_msgs::msg::Node::SharedPtr Forall::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
-	throw UnsupportedConstruct("Forall");
+	plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
+	node->node_type = plansys2_msgs::msg::Node::FORALL;
+	node->node_id = tree.nodes.size();
+	node->name = name;
+	tree.nodes.push_back(*node);
+	
+	std::string type = d.types[params[0]]->name;
+
+	for (const auto& instance: instances_map.at(type)) {
+		plansys2_msgs::msg::Param param;
+		param.name = instance;
+		param.type = type;
+		tree.nodes[node->node_id].parameters.push_back(param);
+
+		std::vector<std::string> new_replace = replace;
+		new_replace.push_back(instance);
+		if(cond) {
+			plansys2_msgs::msg::Node::SharedPtr child = cond->getTree(tree, d, new_replace, instances_map);
+			tree.nodes[node->node_id].children.push_back(child->node_id);
+		}
+	}
+	
+	return node;
 }
 
 void Forall::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Forall.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Forall.cpp
@@ -23,8 +23,8 @@ void Forall::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Forall::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
-    throw UnsupportedConstruct("Forall");
+plansys2_msgs::msg::Node::SharedPtr Forall::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
+	throw UnsupportedConstruct("Forall");
 }
 
 void Forall::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Function.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Function.cpp
@@ -8,7 +8,7 @@ void Function::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< 
 	if ( returnType >= 0 ) s << " - " << d.types[returnType]->name;
 }
 
-plansys2_msgs::msg::Node::SharedPtr Function::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Function::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Function");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/FunctionModifier.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/FunctionModifier.cpp
@@ -40,7 +40,7 @@ void FunctionModifier::PDDLPrint( std::ostream & s, unsigned indent, const Token
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr FunctionModifier::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr FunctionModifier::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     node->node_type = plansys2_msgs::msg::Node::FUNCTION_MODIFIER;
     node->modifier_type = getFunModType(name);
@@ -48,14 +48,14 @@ plansys2_msgs::msg::Node::SharedPtr FunctionModifier::getTree( plansys2_msgs::ms
     tree.nodes.push_back(*node);
 
     if (modifiedGround) {
-        plansys2_msgs::msg::Node::SharedPtr child = modifiedGround->getTree(tree, d, replace);
+        plansys2_msgs::msg::Node::SharedPtr child = modifiedGround->getTree(tree, d, replace); // Is type Ground, so should not need instances
         tree.nodes[node->node_id].children.push_back(child->node_id);
     }
     else {
         std::cerr << "function modifier for total-cost not supported" << std::endl;
     }
 
-    plansys2_msgs::msg::Node::SharedPtr child = modifierExpr->getTree(tree, d, replace);
+    plansys2_msgs::msg::Node::SharedPtr child = modifierExpr->getTree(tree, d, replace, instances_map); // Does it need instances?
     tree.nodes[node->node_id].children.push_back(child->node_id);
 
     return node;

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
@@ -17,7 +17,7 @@ void Ground::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Ground::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Ground::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     if ( d.funcs.index( name ) >= 0) {
         node->node_type = plansys2_msgs::msg::Node::FUNCTION;

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/GroundFunc.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/GroundFunc.cpp
@@ -22,15 +22,15 @@ void GroundFunc<int>::PDDLPrint( std::ostream & s, unsigned indent, const TokenS
 }
 
 template <>
-plansys2_msgs::msg::Node::SharedPtr GroundFunc<double>::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
-    auto node = TypeGround::getTree(tree, d, replace);
+plansys2_msgs::msg::Node::SharedPtr GroundFunc<double>::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
+    auto node = TypeGround::getTree(tree, d, replace); // Ground should not need instances, so is not passed
     node->value = value;
     return node;
 }
 
 template <>
-plansys2_msgs::msg::Node::SharedPtr GroundFunc<int>::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
-    auto node = TypeGround::getTree(tree, d, replace);
+plansys2_msgs::msg::Node::SharedPtr GroundFunc<int>::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
+    auto node = TypeGround::getTree(tree, d, replace); // Ground should not need instances, so is not passed
     node->value = value;
     return node;
 }

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -1,0 +1,52 @@
+
+#include "plansys2_pddl_parser/Domain.h"
+
+namespace parser { namespace pddl {
+
+void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::string > & ts, const Domain & d ) const {
+	tabindent( s, indent );
+	s << "( imply\n";
+
+	TokenStruct< std::string > fstruct( ts );
+
+	tabindent( s, indent + 1 );
+	printParams( 0, s, fstruct, d );
+
+	if ( cond ) cond->PDDLPrint( s, indent + 1, fstruct, d );
+	else {
+		tabindent( s, indent + 1 );
+		s << "()";
+	}
+
+	s << "\n";
+	tabindent( s, indent );
+	s << ")";
+}
+
+plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+    throw UnsupportedConstruct("Imply");
+}
+
+void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {
+	f.next();
+	f.assert_token( "(" );
+
+	TokenStruct< std::string > fs = f.parseTypedList( true, d.types );
+	params = d.convertTypes( fs.types );
+
+	TokenStruct< std::string > fstruct( ts );
+	fstruct.append( fs );
+
+	f.next();
+	f.assert_token( "(" );
+	if ( f.getChar() != ')' ) {
+		cond = d.createCondition( f );
+		cond->parse( f, fstruct, d );
+	}
+	else ++f.c;
+
+	f.next();
+	f.assert_token( ")" );
+}
+
+} } // namespaces

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -25,7 +25,38 @@ void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std
 }
 
 plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
-	throw UnsupportedConstruct("Imply");
+		
+	plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
+	node->node_type = plansys2_msgs::msg::Node::IMPLY;
+	node->node_id = tree.nodes.size();
+	node->name = name;
+	
+	for (unsigned i = 0; i < params.size(); ++i) {
+		plansys2_msgs::msg::Param param;
+		if (i < replace.size()){
+			if (params[i] >= 0)  // param has a variable value; replace by action-args
+			{
+				param.name = replace[i];
+			}
+		} else {
+			param.name = "?" + std::to_string(params[i]);
+		}
+		param.type = d.types[params[i]]->name;
+		node->parameters.push_back(param);
+	}
+	
+	tree.nodes.push_back(*node);
+
+	if (cond_1){
+		plansys2_msgs::msg::Node::SharedPtr child_1 = cond_1->getTree(tree, d, replace); // Could conditions need instances?
+		tree.nodes[node->node_id].children.push_back(child_1->node_id);
+	}
+
+	if(cond_2){
+		plansys2_msgs::msg::Node::SharedPtr child_2 = cond_2->getTree(tree, d, replace); // Could conditions need instances?
+		tree.nodes[node->node_id].children.push_back(child_2->node_id);
+	}
+	return node;
 }
 
 void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -12,7 +12,8 @@ void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std
 	tabindent( s, indent + 1 );
 	printParams( 0, s, fstruct, d );
 
-	if ( cond ) cond->PDDLPrint( s, indent + 1, fstruct, d );
+	if ( cond_1 ) cond_1->PDDLPrint( s, indent + 1, fstruct, d );
+	if (cond_2) cond_2->PDDLPrint( s, indent + 1, fstruct, d );
 	else {
 		tabindent( s, indent + 1 );
 		s << "()";
@@ -31,17 +32,17 @@ void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d
 	f.next();
 	f.assert_token( "(" );
 
-	TokenStruct< std::string > fs = f.parseTypedList( true, d.types );
-	params = d.convertTypes( fs.types );
-
-	TokenStruct< std::string > fstruct( ts );
-	fstruct.append( fs );
+	if (f.getChar() != ')' ) {
+		cond_1 = d.createCondition( f );
+		cond_1->parse( f, ts, d );
+	}
+	else ++f.c;
 
 	f.next();
 	f.assert_token( "(" );
 	if ( f.getChar() != ')' ) {
-		cond = d.createCondition( f );
-		cond->parse( f, fstruct, d );
+		cond_2 = d.createCondition( f );
+		cond_2->parse( f, ts, d );
 	}
 	else ++f.c;
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -24,8 +24,8 @@ void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
-    throw UnsupportedConstruct("Imply");
+plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
+	throw UnsupportedConstruct("Imply");
 }
 
 void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -31,7 +31,7 @@ plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & t
 void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d ) {
 	f.next();
 	f.assert_token( "(" );
-
+	params = d.convertTypes(ts.types);
 	if (f.getChar() != ')' ) {
 		cond_1 = d.createCondition( f );
 		cond_1->parse( f, ts, d );

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Imply.cpp
@@ -12,8 +12,8 @@ void Imply::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std
 	tabindent( s, indent + 1 );
 	printParams( 0, s, fstruct, d );
 
-	if ( cond_1 ) cond_1->PDDLPrint( s, indent + 1, fstruct, d );
-	if (cond_2) cond_2->PDDLPrint( s, indent + 1, fstruct, d );
+	if ( left ) left->PDDLPrint( s, indent + 1, fstruct, d );
+	if (right) right->PDDLPrint( s, indent + 1, fstruct, d );
 	else {
 		tabindent( s, indent + 1 );
 		s << "()";
@@ -47,13 +47,13 @@ plansys2_msgs::msg::Node::SharedPtr Imply::getTree( plansys2_msgs::msg::Tree & t
 	
 	tree.nodes.push_back(*node);
 
-	if (cond_1){
-		plansys2_msgs::msg::Node::SharedPtr child_1 = cond_1->getTree(tree, d, replace); // Could conditions need instances?
+	if (left){
+		plansys2_msgs::msg::Node::SharedPtr child_1 = left->getTree(tree, d, replace); // Could conditions need instances?
 		tree.nodes[node->node_id].children.push_back(child_1->node_id);
 	}
 
-	if(cond_2){
-		plansys2_msgs::msg::Node::SharedPtr child_2 = cond_2->getTree(tree, d, replace); // Could conditions need instances?
+	if(right){
+		plansys2_msgs::msg::Node::SharedPtr child_2 = right->getTree(tree, d, replace); // Could conditions need instances?
 		tree.nodes[node->node_id].children.push_back(child_2->node_id);
 	}
 	return node;
@@ -64,16 +64,16 @@ void Imply::parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d
 	f.assert_token( "(" );
 	params = d.convertTypes(ts.types);
 	if (f.getChar() != ')' ) {
-		cond_1 = d.createCondition( f );
-		cond_1->parse( f, ts, d );
+		left = d.createCondition( f );
+		left->parse( f, ts, d );
 	}
 	else ++f.c;
 
 	f.next();
 	f.assert_token( "(" );
 	if ( f.getChar() != ')' ) {
-		cond_2 = d.createCondition( f );
-		cond_2->parse( f, ts, d );
+		right = d.createCondition( f );
+		right->parse( f, ts, d );
 	}
 	else ++f.c;
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Lifted.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Lifted.cpp
@@ -14,7 +14,7 @@ void Lifted::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< st
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Lifted::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Lifted::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Lifted");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Not.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Not.cpp
@@ -10,14 +10,14 @@ void Not::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Not::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Not::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     plansys2_msgs::msg::Node::SharedPtr node = std::make_shared<plansys2_msgs::msg::Node>();
     node->node_type = plansys2_msgs::msg::Node::NOT;
     node->node_id = tree.nodes.size();
     tree.nodes.push_back(*node);
 
     if (cond) {
-        plansys2_msgs::msg::Node::SharedPtr child = cond->getTree(tree, d, replace);
+        plansys2_msgs::msg::Node::SharedPtr child = cond->getTree(tree, d, replace, instances_map);
         tree.nodes[node->node_id].children.push_back(child->node_id);
     }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Oneof.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Oneof.cpp
@@ -14,7 +14,7 @@ void Oneof::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Oneof::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Oneof::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Oneof");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Or.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Or.cpp
@@ -22,7 +22,7 @@ void Or::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std::s
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr Or::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr Or::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("Or");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/TemporalAction.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/TemporalAction.cpp
@@ -46,7 +46,7 @@ void TemporalAction::PDDLPrint( std::ostream & s, unsigned indent, const TokenSt
 	s << ")\n";
 }
 
-plansys2_msgs::msg::Node::SharedPtr TemporalAction::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr TemporalAction::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("TemporalAction");
 }
 

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/TypeGround.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/TypeGround.cpp
@@ -11,8 +11,8 @@ void TypeGround::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct
 	s << " )";
 }
 
-plansys2_msgs::msg::Node::SharedPtr TypeGround::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
-    return Ground::getTree(tree, d, replace);
+plansys2_msgs::msg::Node::SharedPtr TypeGround::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
+    return Ground::getTree(tree, d, replace); // Ground should not need instances, so is not passed
 }
 
 void TypeGround::insert( Domain & d, const StringVec & v ) {

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -758,9 +758,13 @@ plansys2_msgs::msg::Node fromStringPredicate(const std::string & predicate)
   }
 
   tokens[0].erase(0, 1);
+  if (tokens[0].back() == ')') 
+    tokens[0].pop_back();
+
   ret.name = tokens[0];
 
-  tokens.back().pop_back();
+  if (tokens.size() > 1 && tokens.back().back() == ')') 
+    tokens.back().pop_back();
 
   for (size_t i = 1; i < tokens.size(); i++) {
     plansys2_msgs::msg::Param param;

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/When.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/When.cpp
@@ -22,7 +22,7 @@ void When::PDDLPrint( std::ostream & s, unsigned indent, const TokenStruct< std:
 	s << ")";
 }
 
-plansys2_msgs::msg::Node::SharedPtr When::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace ) const {
+plansys2_msgs::msg::Node::SharedPtr When::getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace, const std::map<std::string, std::vector<std::string>> & instances_map ) const {
     throw UnsupportedConstruct("When");
 }
 

--- a/plansys2_pddl_parser/test/pddl/dom1.pddl
+++ b/plansys2_pddl_parser/test/pddl/dom1.pddl
@@ -58,4 +58,25 @@
     )
 )
 
+(:durative-action action_test3
+    :parameters (?r - robot)
+    :duration ( = ?duration 20)
+    :condition (and
+        (at start
+            (forall
+                (?ro - room)
+                (imply
+                    (robot_at ?r ?ro)
+                    (charging_point_at ?ro)
+                )
+            )
+        )
+        (over all (and (> (battery_level ?r) 1) (< (battery_level ?r) 200)) )
+    )
+    :effect (and
+         (at end (increase (battery_level ?r) (* ?duration 5.0)))
+         (at end (battery_full ?r))
+    )
+)
+
 )

--- a/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
@@ -301,6 +301,36 @@ std::tuple<bool, bool, double> evaluate(
     case plansys2_msgs::msg::Node::NUMBER: {
         return std::make_tuple(true, true, tree.nodes[node_id].value);
       }
+    
+    case plansys2_msgs::msg::Node::FORALL: {
+      bool success = true;
+      bool truth_value = true;
+
+      for (auto & child_id : tree.nodes[node_id].children) {
+        std::tuple<bool, bool, double> result =
+          evaluate(
+          tree, problem_client, predicates, functions, apply, use_state, child_id,
+          negate);
+        success = success && std::get<0>(result);
+        truth_value = truth_value && std::get<1>(result);
+      }
+      return std::make_tuple(success, truth_value, 0);
+    }
+
+    case plansys2_msgs::msg::Node::IMPLY: {
+      std::tuple<bool, bool, double> left = evaluate(
+        tree, problem_client, predicates,
+        functions, false, use_state, tree.nodes[node_id].children[0], !negate); // negated as imply evaluates to !left || right
+        // apply set to false as imply can't be used in effects. Maybe raise error if true?
+      std::tuple<bool, bool, double> right = evaluate(
+        tree, problem_client,
+        predicates, functions, false, use_state, tree.nodes[node_id].children[1],
+        negate);
+
+      bool eval = std::get<1>(left) || std::get<1>(right);
+
+      return std::make_tuple(std::get<0>(left) && std::get<0>(right), std::get<1>(left) || std::get<1>(right), 0);
+    }
 
     default:
       std::cerr << "evaluate: Error parsing expresion [" <<

--- a/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/Utils.cpp
@@ -301,36 +301,39 @@ std::tuple<bool, bool, double> evaluate(
     case plansys2_msgs::msg::Node::NUMBER: {
         return std::make_tuple(true, true, tree.nodes[node_id].value);
       }
-    
-    case plansys2_msgs::msg::Node::FORALL: {
-      bool success = true;
-      bool truth_value = true;
 
-      for (auto & child_id : tree.nodes[node_id].children) {
-        std::tuple<bool, bool, double> result =
-          evaluate(
-          tree, problem_client, predicates, functions, apply, use_state, child_id,
-          negate);
-        success = success && std::get<0>(result);
-        truth_value = truth_value && std::get<1>(result);
+    case plansys2_msgs::msg::Node::FORALL: {
+        bool success = true;
+        bool truth_value = true;
+
+        for (auto & child_id : tree.nodes[node_id].children) {
+          std::tuple<bool, bool, double> result =
+            evaluate(
+            tree, problem_client, predicates, functions, apply, use_state, child_id,
+            negate);
+          success = success && std::get<0>(result);
+          truth_value = truth_value && std::get<1>(result);
+        }
+        return std::make_tuple(success, truth_value, 0);
       }
-      return std::make_tuple(success, truth_value, 0);
-    }
 
     case plansys2_msgs::msg::Node::IMPLY: {
-      std::tuple<bool, bool, double> left = evaluate(
-        tree, problem_client, predicates,
-        functions, false, use_state, tree.nodes[node_id].children[0], !negate); // negated as imply evaluates to !left || right
+        std::tuple<bool, bool, double> left = evaluate(
+          tree, problem_client, predicates,
+          functions, false, use_state, tree.nodes[node_id].children[0], !negate);
+        // negated as imply evaluates to !left || right
         // apply set to false as imply can't be used in effects. Maybe raise error if true?
-      std::tuple<bool, bool, double> right = evaluate(
-        tree, problem_client,
-        predicates, functions, false, use_state, tree.nodes[node_id].children[1],
-        negate);
+        std::tuple<bool, bool, double> right = evaluate(
+          tree, problem_client,
+          predicates, functions, false, use_state, tree.nodes[node_id].children[1],
+          negate);
 
-      bool eval = std::get<1>(left) || std::get<1>(right);
+        bool eval = std::get<1>(left) || std::get<1>(right);
 
-      return std::make_tuple(std::get<0>(left) && std::get<0>(right), std::get<1>(left) || std::get<1>(right), 0);
-    }
+        return std::make_tuple(
+          std::get<0>(left) && std::get<0>(right), std::get<1>(
+            left) || std::get<1>(right), 0);
+      }
 
     default:
       std::cerr << "evaluate: Error parsing expresion [" <<


### PR DESCRIPTION
## Changes:

This pull request introduces several changes to the `plansys2_domain_expert`, `plansys2_problem_expert`, `plansys2_pddl_parser` and `plansys2_executor` packages, primarily to enhance the handling of durative actions by introducing new PDDL functionality using _forall_ and _imply_ and corresponding tests.

### Parser updates:
- Corrected parsing method to match intended functionality of _imply_ key in `Imply.cpp`.
- Implemented `getTree` methods for both _forall_ and _imply_. Respective changes in `Forall.cpp` and `Imply.cpp`.
- Added optional _instances_map_ field to pure virtual method in `Condition.h` and respective derived classes to allow _forall_ to supplement action params with instances from typed lists.

### Domain expert updates:
- To support BT creation for forall and its child trees, instances are now provided to the `getDurativeAction` method to supply the necessary instances to the forall `getTree` method. 
- Updated pure virtual method `DomainExpertInterface::getDurativeAction` and its overrides to optionally accept a `plansys2_msgs::msg::Param` vector of instances. 
- `DomainExpert::getDurativeAction` converts this vector into a map of format **_instance-type : instances_** and supplies this to all three precondition types. Effects are excluded at this point, as POPF support for forall in effects is limited. Extending support for forall in effects is simply a matter of providing these instances to the _AtStart_ and _AtEnd_ effects. 

### Updates to executor nodes:
- All instances are requested from the problem expert when a request to execute is recieved.
- All calls to the `getDurativeAction` method of the domain client are supplied with these instances in `ExecutorNode.cpp` and `BTBuilder.cpp`.

### Updates to problem expert:
- New cases for _forall_ and _imply_ are are added to the `evaluate` method in `Utils.cpp`.
- As _imply_ can only be used in preconditions, no logic for effect application is implemented for its case. 

### New PDDL functionality and tests:
- A new test case is added to `bt_node_test.cpp` within the executor package with the appropriate pddl domain to test the new functionalities implemented. 
