### PR TITLE
Mejora de legibilidad y eliminacion de mensajes de error innecesarios.

### DIFF
--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -274,16 +274,16 @@ std::tuple<uint8_t, int> getExpr(const std::string & input)
     }
   }
 
-  if (expr_type == plansys2_msgs::msg::Node::UNKNOWN) {
-    std::cerr << "getExpr: Error parsing expresion [" << input << "]" << std::endl;
-  }
-
   return std::make_tuple(expr_type, first);
 }
 
 uint8_t getExprType(const std::string & input)
 {
   std::tuple<uint8_t, int> result = getExpr(input);
+  if (std::get<0>(result) == plansys2_msgs::msg::Node::UNKNOWN) {
+    std::cerr << "getExprType: Error parsing expresion [" << input << "]" << std::endl;
+  }
+
   return std::get<0>(result);
 }
 
@@ -563,9 +563,9 @@ std::string toStringAnd(const plansys2_msgs::msg::Tree & tree, uint32_t node_id,
   }
 
   for (auto child_id : tree.nodes[node_id].children) {
-    ret += toString(tree, child_id, negate);
+    ret += "\n" + toString(tree, child_id, negate);
   }
-  ret += ")";
+  ret += "\n)";
 
   return ret;
 }
@@ -589,9 +589,9 @@ std::string toStringOr(const plansys2_msgs::msg::Tree & tree, uint32_t node_id, 
   }
 
   for (auto child_id : tree.nodes[node_id].children) {
-    ret += toString(tree, child_id, negate);
+    ret += "\n" + toString(tree, child_id, negate);
   }
-  ret += ")";
+  ret += "\n)";
 
   return ret;
 }

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -522,7 +522,7 @@ Terminal::process_get_problem(std::vector<std::string> & command, std::ostringst
       }
     } else if (command[0] == "goal") {
       auto goal = problem_client_->getGoal();
-      os << "Goal: " << parser::pddl::toString(goal) << std::endl;
+      os << "Goal: \n" << parser::pddl::toString(goal) << std::endl;
     }
   } else {
     os << "\tUsage: \n\t\tget problem [instances|predicates|functions|goal]..." <<


### PR DESCRIPTION
**Legibilidad:**
Métodos toStringAnd y toStringOr cambiados en el plansys2_pddl_parser para que cada predicado aparezca en una linea distinta y hacerlo así más legible. Además, he añadido un salto de línea en Terminal.cpp para que leer el goal sea más sencillo.

**Mensaje de error inadecuado:** 
Cambio de lugar del mensaje de error "Error parsing expression", de getExpr a getExprType. getExpr se llama aun cuando no sabemos si el input es una expresión, por lo que obtener como resultado la expresión UNKNOWN no debería considerase error. getExprType se llama cuando SI sabemos que el input es una expresión, así que debe considerase un error no averiguar su tipo. Ahora se mostrará el mensaje de error solo cuando sea necesario: si sabemos que es una expresión pero no logramos averiguar su tipo.
