### PR TITLE
Change in AND/OR readability and fixed error in 'set goal' execution

### DIFF
--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -274,16 +274,16 @@ std::tuple<uint8_t, int> getExpr(const std::string & input)
     }
   }
 
-  if (expr_type == plansys2_msgs::msg::Node::UNKNOWN) {
-    std::cerr << "getExpr: Error parsing expresion [" << input << "]" << std::endl;
-  }
-
   return std::make_tuple(expr_type, first);
 }
 
 uint8_t getExprType(const std::string & input)
 {
   std::tuple<uint8_t, int> result = getExpr(input);
+  if (std::get<0>(result) == plansys2_msgs::msg::Node::UNKNOWN) {
+    std::cerr << "getExprType: Error parsing expresion [" << input << "]" << std::endl;
+  }
+
   return std::get<0>(result);
 }
 
@@ -563,9 +563,9 @@ std::string toStringAnd(const plansys2_msgs::msg::Tree & tree, uint32_t node_id,
   }
 
   for (auto child_id : tree.nodes[node_id].children) {
-    ret += toString(tree, child_id, negate);
+    ret += "\n" + toString(tree, child_id, negate);
   }
-  ret += ")";
+  ret += "\n)";
 
   return ret;
 }
@@ -589,9 +589,9 @@ std::string toStringOr(const plansys2_msgs::msg::Tree & tree, uint32_t node_id, 
   }
 
   for (auto child_id : tree.nodes[node_id].children) {
-    ret += toString(tree, child_id, negate);
+    ret += "\n" + toString(tree, child_id, negate);
   }
-  ret += ")";
+  ret += "\n)";
 
   return ret;
 }

--- a/plansys2_pddl_parser/test/pddl_parser_test.cpp
+++ b/plansys2_pddl_parser/test/pddl_parser_test.cpp
@@ -87,8 +87,8 @@ TEST(PDDLParserTestCase, exists_get_tree)
 
   ASSERT_EQ(
     str,
-    "(and (exists (?1) (and (robot_at ?0 ?1)(charging_point_at ?1)))(and (>  (battery_level ?0) "
-    "1.000000)(<  (battery_level ?0) 200.000000)))");
+    "(and \n(exists (?1) (and \n(robot_at ?0 ?1)\n(charging_point_at ?1)\n))\n"
+    "(and \n(>  (battery_level ?0) 1.000000)\n(<  (battery_level ?0) 200.000000)\n)\n)");
 
   plansys2_msgs::msg::Tree tree2;
   std::vector<std::string> replace = {"rob1"};
@@ -96,12 +96,12 @@ TEST(PDDLParserTestCase, exists_get_tree)
   std::string str2 = parser::pddl::toString(tree2);
   ASSERT_EQ(
     str2,
-    "(and (exists (?1) (and (robot_at rob1 ?1)(charging_point_at ?1)))(and (>  (battery_level "
-    "rob1) 1.000000)(<  (battery_level rob1) 200.000000)))");
+    "(and \n(exists (?1) (and \n(robot_at rob1 ?1)\n(charging_point_at ?1)\n))\n"
+    "(and \n(>  (battery_level rob1) 1.000000)\n(<  (battery_level rob1) 200.000000)\n)\n)");
 
   auto action2 = domain.actions.get("action_test5");
   plansys2_msgs::msg::Tree tree3;
   action2->pre->getTree(tree3, domain);
   std::string str3 = parser::pddl::toString(tree3);
-  ASSERT_EQ(str3, "(exists (?1 ?2) (and (robot_at ?0 ?1)(connected ?1 ?2)))");
+  ASSERT_EQ(str3, "(exists (?1 ?2) (and \n(robot_at ?0 ?1)\n(connected ?1 ?2)\n))");
 }


### PR DESCRIPTION
**Readability**  
-Updated `toStringAnd` and `toStringOr` methods in pddl parser package to ensure each predicate appears on a separate line.

**Extra Error Message**  
Moved the error message `"Error parsing expression"` from `getExpr` to `getExprType` methods in pddl parser.
`getExpr` is called even when the input might not be an expression, so returning `UNKNOWN` should not be considered an error, which was what was causing the problem.
`getExprType` is only called when the input is known to be an expression, making it the correct place to trigger an error if its type cannot be determined. 

Running `set goal` no longer produces incorrect error messages.