### PR TITLE
Fix scheduled CI jobs in jazzy-devel branch

### DIFF
--- a/.github/workflows/jazzy-devel.yaml
+++ b/.github/workflows/jazzy-devel.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
+          ref: jazzy-devel
           target-ros2-distro: jazzy
           colcon-defaults: |
             {


### PR DESCRIPTION
The weekly scheduled job for the `jazzy-devel` branch was actually using the latest `rolling` commit. This PR should fix that.

Thanks to @Juancams for the tip.