### PR TITLE
Closes #352

### DIFF
--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -156,7 +156,7 @@ POPFPlanSolver::parse_plan_result(const std::string & plan_path)
     plan_file.close();
   }
 
-  if (solution && !plan.items.empty()) {
+  if (solution) {
     return plan;
   } else {
     return {};

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -818,6 +818,9 @@ Terminal::execute_plan(int items)
   if (!plan.has_value()) {
     std::cout << "Plan could not be computed " << std::endl;
     return;
+  } else if (plan.value().items.size() == 0) {
+    std::cout << "Planning succeeded, but there are no actions to execute " << std::endl;
+    return;
   }
 
   if (items > 0 && items <= plan.value().items.size()) {


### PR DESCRIPTION
Fix POPF plugin issue when retrieving a successful plan (#352) and add a message in the terminal for plans with no actions (but not empty).