### PR TITLE
Fix deprecation of ament_target_dependencies

### DIFF
--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -21,13 +21,13 @@ jobs:
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.9
+        uses: ros-tooling/setup-ros@0.7.12
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
         run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.13
+        uses: ros-tooling/action-ros-ci@0.4.3
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
           target-ros2-distro: rolling

--- a/plansys2_bringup/CMakeLists.txt
+++ b/plansys2_bringup/CMakeLists.txt
@@ -10,9 +10,16 @@ find_package(plansys2_planner REQUIRED)
 find_package(plansys2_executor REQUIRED)
 find_package(plansys2_lifecycle_manager REQUIRED)
 
-
-
 set(dependencies
+    rclcpp::rclcpp
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_planner::plansys2_planner
+    plansys2_executor::plansys2_executor
+    plansys2_lifecycle_manager::plansys2_lifecycle_manager
+)
+
+set(package_dependencies
     rclcpp
     plansys2_domain_expert
     plansys2_problem_expert
@@ -21,10 +28,11 @@ set(dependencies
     plansys2_lifecycle_manager
 )
 
+
 add_executable(plansys2_node
   src/plansys2_node.cpp
 )
-ament_target_dependencies(plansys2_node ${dependencies})
+target_link_libraries(plansys2_node PUBLIC ${dependencies})
 target_compile_definitions(plansys2_node PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 if(BUILD_TESTING)
@@ -37,8 +45,8 @@ install(TARGETS
   plansys2_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(${package_dependencies})
 ament_package()

--- a/plansys2_bt_actions/CMakeLists.txt
+++ b/plansys2_bt_actions/CMakeLists.txt
@@ -13,9 +13,17 @@ find_package(behaviortree_cpp REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
-
-
 set(dependencies
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_lifecycle::rclcpp_lifecycle
+    plansys2_executor::plansys2_executor
+    behaviortree_cpp::behaviortree_cpp
+    ${action_msgs_TARGETS}
+    ${lifecycle_msgs_TARGETS}
+)
+
+set(package_dependencies
     rclcpp
     rclcpp_action
     rclcpp_lifecycle
@@ -32,24 +40,35 @@ set(BT_ACTIONS_SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${BT_ACTIONS_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(bt_action_node
   src/bt_action_node.cpp
 )
-ament_target_dependencies(bt_action_node ${dependencies})
-target_link_libraries(bt_action_node ${PROJECT_NAME})
+target_link_libraries(bt_action_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS
   bt_action_node
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
+  bt_action_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -61,12 +80,14 @@ if(BUILD_TESTING)
   find_package(test_msgs REQUIRED)
   find_package(geometry_msgs REQUIRED)
 
-  set(dependencies ${dependencies} plansys2_msgs test_msgs geometry_msgs)
+  set(dependencies ${dependencies} ${plansys2_msgs_TARGETS} ${test_msgs_TARGETS} ${geometry_msgs_TARGETS})
 
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
-ament_export_dependencies(${dependencies})
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_bt_actions/test/unit/CMakeLists.txt
+++ b/plansys2_bt_actions/test/unit/CMakeLists.txt
@@ -17,15 +17,12 @@ add_library(plansys2_failure_test_nodes SHARED
 list(APPEND plugin_libs plansys2_failure_test_nodes)
 
 foreach(bt_plugin ${plugin_libs})
-  ament_target_dependencies(${bt_plugin} ${dependencies})
+  target_link_libraries(${bt_plugin} ${dependencies})
   target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)
 endforeach()
 
 ament_add_gtest(bt_action_test bt_action_test.cpp)
-target_link_libraries(bt_action_test
-  ${PROJECT_NAME}
-)
-ament_target_dependencies(bt_action_test ${dependencies})
+target_link_libraries(bt_action_test ${PROJECT_NAME} ${dependencies})
 
 install(DIRECTORY ../behavior_tree
   DESTINATION share/${PROJECT_NAME}/test

--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -9,14 +9,20 @@ find_package(pluginlib REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 
-
-
 set(dependencies
-    rclcpp
-    rclcpp_lifecycle
-    pluginlib
-    plansys2_pddl_parser
-    plansys2_msgs
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  pluginlib::pluginlib
+  plansys2_pddl_parser::plansys2_pddl_parser
+  ${plansys2_msgs_TARGETS}
+)
+
+set(package_dependencies
+  rclcpp
+  rclcpp_lifecycle
+  pluginlib
+  plansys2_pddl_parser
+  plansys2_msgs
 )
 
 include_directories(include)
@@ -25,17 +31,22 @@ add_library(${PROJECT_NAME} SHARED
   src/plansys2_core/Utils.cpp
   src/plansys2_core/PlanSolverBase.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -46,8 +57,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
-ament_export_dependencies(${dependencies})
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_domain_expert/CMakeLists.txt
+++ b/plansys2_domain_expert/CMakeLists.txt
@@ -14,9 +14,20 @@ find_package(plansys2_popf_plan_solver REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
-
-
 set(dependencies
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_lifecycle::rclcpp_lifecycle
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ament_index_cpp::ament_index_cpp
+    plansys2_core::plansys2_core
+    plansys2_popf_plan_solver::plansys2_popf_plan_solver
+    ${plansys2_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${lifecycle_msgs_TARGETS}
+)
+
+set(package_dependencies
     rclcpp
     rclcpp_action
     rclcpp_lifecycle
@@ -39,26 +50,36 @@ set(DOMAIN_EXPERT_SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${DOMAIN_EXPERT_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(domain_expert_node
   src/domain_expert_node.cpp
 )
-ament_target_dependencies(domain_expert_node ${dependencies})
-target_link_libraries(domain_expert_node ${PROJECT_NAME})
+target_link_libraries(domain_expert_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
   domain_expert_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -69,8 +90,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -23,9 +23,27 @@ find_package(behaviortree_cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
-
-
 set(dependencies
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    rclcpp_cascade_lifecycle::rclcpp_cascade_lifecycle
+    rclcpp_action::rclcpp_action
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ament_index_cpp::ament_index_cpp
+    plansys2_core::plansys2_core
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_planner::plansys2_planner
+    pluginlib::pluginlib
+    behaviortree_cpp::behaviortree_cpp
+    ${lifecycle_msgs_TARGETS}
+    ${plansys2_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+)
+
+
+set(package_dependencies
     eigen3_cmake_module
     Eigen3
     rclcpp
@@ -68,43 +86,58 @@ set(EXECUTOR_SOURCES
 
 
 add_library(${PROJECT_NAME} SHARED ${EXECUTOR_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
-target_link_libraries(${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(executor_node
   src/executor_node.cpp
 )
-ament_target_dependencies(executor_node ${dependencies})
-target_link_libraries(executor_node ${PROJECT_NAME})
+target_link_libraries(executor_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
 add_executable(compute_bt
   src/compute_bt.cpp
 )
-ament_target_dependencies(compute_bt ${dependencies})
-target_link_libraries(compute_bt ${PROJECT_NAME})
+target_link_libraries(compute_bt PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 add_library(bt_builder_plugins SHARED
   src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
   src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
 )
-ament_target_dependencies(bt_builder_plugins ${dependencies})
+target_link_libraries(bt_builder_plugins PUBLIC ${dependencies})
 
 pluginlib_export_plugin_description_file(plansys2_executor plugins.xml)
 
 install(DIRECTORY launch behavior_trees DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
+  bt_builder_plugins EXPORT bt_builder_plugins
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
   bt_builder_plugins
   executor_node
   compute_bt
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -116,8 +149,8 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME} bt_builder_plugins)
-ament_export_dependencies(${dependencies})
-
+ament_export_targets(${PROJECT_NAME} bt_builder_plugins)
+ament_export_dependencies(${package_dependencies})
 ament_package()

--- a/plansys2_executor/test/unit/CMakeLists.txt
+++ b/plansys2_executor/test/unit/CMakeLists.txt
@@ -12,23 +12,19 @@ target_link_libraries(action_execution_test ${PROJECT_NAME})
 ament_add_gtest(execution_tree_test execution_tree_test.cpp)
 target_compile_definitions(execution_tree_test
   PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(execution_tree_test ${PROJECT_NAME})
-ament_target_dependencies(execution_tree_test ${dependencies})
+target_link_libraries(execution_tree_test ${PROJECT_NAME} ${dependencies})
 
 ament_add_gtest(simple_btbuilder_tests simple_btbuilder_tests.cpp)
 target_compile_definitions(simple_btbuilder_tests
   PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(simple_btbuilder_tests ${PROJECT_NAME} bt_builder_plugins)
-ament_target_dependencies(simple_btbuilder_tests ${dependencies})
+target_link_libraries(simple_btbuilder_tests ${PROJECT_NAME} ${dependencies} bt_builder_plugins)
 
 ament_add_gtest(bt_node_test bt_node_test.cpp)
 target_compile_definitions(bt_node_test
   PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(bt_node_test ${PROJECT_NAME})
-ament_target_dependencies(bt_node_test ${dependencies})
+target_link_libraries(bt_node_test ${PROJECT_NAME} ${dependencies})
 
 ament_add_gtest(bt_node_test_charging bt_node_test_charging.cpp)
 target_compile_definitions(bt_node_test_charging
   PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(bt_node_test_charging ${PROJECT_NAME})
-ament_target_dependencies(bt_node_test_charging ${dependencies})
+target_link_libraries(bt_node_test_charging ${PROJECT_NAME} ${dependencies})

--- a/plansys2_lifecycle_manager/CMakeLists.txt
+++ b/plansys2_lifecycle_manager/CMakeLists.txt
@@ -8,6 +8,12 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
 set(dependencies
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    ${lifecycle_msgs_TARGETS}
+)
+
+set(package_dependencies
     rclcpp
     rclcpp_lifecycle
     lifecycle_msgs
@@ -18,24 +24,34 @@ include_directories(include)
 add_library(${PROJECT_NAME}
   src/plansys2_lifecycle_manager/lifecycle_manager.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 
 add_executable(lifecycle_manager_node
   src/lifecycle_manager_node.cpp)
-ament_target_dependencies(lifecycle_manager_node ${dependencies})
-target_link_libraries(lifecycle_manager_node ${PROJECT_NAME})
+target_link_libraries(lifecycle_manager_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
   lifecycle_manager_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -46,8 +62,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_lifecycle_manager/test/CMakeLists.txt
+++ b/plansys2_lifecycle_manager/test/CMakeLists.txt
@@ -1,3 +1,2 @@
 ament_add_gtest(lf_manager_test lf_manager_test.cpp)
-ament_target_dependencies(lf_manager_test ${dependencies})
-target_link_libraries(lf_manager_test ${PROJECT_NAME})
+target_link_libraries(lf_manager_test ${PROJECT_NAME} ${dependencies})

--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -7,12 +7,16 @@ find_package(rclcpp REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
-
-
 set(dependencies
-    rclcpp
-    plansys2_msgs
-    std_msgs
+    rclcpp::rclcpp
+    ${plansys2_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+)
+
+set(package_dependencies
+  rclcpp
+  plansys2_msgs
+  std_msgs
 )
 
 include_directories(include)
@@ -41,21 +45,32 @@ set(PDDL-PARSER-SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${PDDL-PARSER-SOURCES})
-ament_target_dependencies(${PROJECT_NAME} rclcpp plansys2_msgs)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(parser src/parser.cpp)
-target_link_libraries(parser ${PROJECT_NAME})
+target_link_libraries(parser PUBLIC ${PROJECT_NAME})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
   parser
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -63,12 +78,13 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_index_cpp REQUIRED)
-  set(dependencies ${dependencies} ament_index_cpp)
+  set(dependencies ${dependencies} ament_index_cpp::ament_index_cpp)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_pddl_parser/test/CMakeLists.txt
+++ b/plansys2_pddl_parser/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 ament_add_gtest(pddl_parser_test pddl_parser_test.cpp TIMEOUT 120)
-ament_target_dependencies(pddl_parser_test ${dependencies})
-target_link_libraries(pddl_parser_test plansys2_pddl_parser)
+target_link_libraries(pddl_parser_test ${dependencies} ${PROJECT_NAME})
 
 install(DIRECTORY
   pddl

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -18,8 +18,23 @@ find_package(std_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
 
-
 set(dependencies
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  rclcpp_lifecycle::rclcpp_lifecycle
+  plansys2_core::plansys2_core
+  plansys2_pddl_parser::plansys2_pddl_parser
+  ament_index_cpp::ament_index_cpp
+  plansys2_domain_expert::plansys2_domain_expert
+  plansys2_problem_expert::plansys2_problem_expert
+  plansys2_popf_plan_solver::plansys2_popf_plan_solver
+  pluginlib::pluginlib
+  ${plansys2_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${lifecycle_msgs_TARGETS}
+)
+
+set(package_dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
@@ -43,28 +58,39 @@ set(PLANNER_SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${PLANNER_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_executable(planner_node
   src/planner_node.cpp
 )
-ament_target_dependencies(planner_node ${dependencies})
 target_compile_definitions(planner_node PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_link_libraries(planner_node ${PROJECT_NAME})
+target_link_libraries(planner_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
+
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME}
-  planner_node
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(TARGETS
+  planner_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -75,8 +101,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_popf_plan_solver/CMakeLists.txt
+++ b/plansys2_popf_plan_solver/CMakeLists.txt
@@ -9,8 +9,14 @@ find_package(plansys2_core REQUIRED)
 find_package(pluginlib REQUIRED)
 
 
-
 set(dependencies
+  rclcpp::rclcpp
+  ament_index_cpp::ament_index_cpp
+  plansys2_core::plansys2_core
+  pluginlib::pluginlib
+)
+
+set(package_dependencies
   rclcpp
   ament_index_cpp
   plansys2_core
@@ -24,14 +30,19 @@ include_directories(
 add_library(${PROJECT_NAME} SHARED
   src/plansys2_popf_plan_solver/popf_plan_solver.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 pluginlib_export_plugin_description_file(plansys2_core plansys2_popf_plan_solver_plugin.xml)
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(FILES plansys2_popf_plan_solver_plugin.xml
@@ -39,10 +50,10 @@ install(FILES plansys2_popf_plan_solver_plugin.xml
 )
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -53,8 +64,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_problem_expert/CMakeLists.txt
+++ b/plansys2_problem_expert/CMakeLists.txt
@@ -15,8 +15,20 @@ find_package(std_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
 
-
 set(dependencies
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_lifecycle::rclcpp_lifecycle
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ament_index_cpp::ament_index_cpp
+    plansys2_core::plansys2_core
+    plansys2_domain_expert::plansys2_domain_expert
+    ${plansys2_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${lifecycle_msgs_TARGETS}
+)
+
+set(package_dependencies
     rclcpp
     rclcpp_action
     rclcpp_lifecycle
@@ -39,27 +51,38 @@ set(PROBLEM_EXPERT_SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${PROBLEM_EXPERT_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(problem_expert_node
   src/problem_expert_node.cpp
 )
-ament_target_dependencies(problem_expert_node ${dependencies})
-target_link_libraries(problem_expert_node ${PROJECT_NAME})
+target_link_libraries(problem_expert_node PUBLIC ${PROJECT_NAME} ${dependencies})
 
-install(DIRECTORY include/
-  DESTINATION include/
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS
   problem_expert_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -69,8 +92,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_terminal/CMakeLists.txt
+++ b/plansys2_terminal/CMakeLists.txt
@@ -14,37 +14,36 @@ find_package(plansys2_executor REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 
 
-
 set(dependencies
-    rclcpp
-    rclcpp_action
-    rclcpp_lifecycle
-    plansys2_msgs
-    plansys2_domain_expert
-    plansys2_problem_expert
-    plansys2_planner
-    plansys2_executor
-    plansys2_pddl_parser
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_lifecycle::rclcpp_lifecycle
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_planner::plansys2_planner
+    plansys2_executor::plansys2_executor
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ${plansys2_msgs_TARGETS}
 )
 
 include_directories(include)
 
 add_library(terminal SHARED
-  src/plansys2_terminal/Terminal.cpp)
-ament_target_dependencies(terminal ${dependencies})
+  src/plansys2_terminal/Terminal.cpp
+)
+target_link_libraries(terminal PUBLIC ${dependencies})
 target_compile_definitions(terminal PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_executable(${PROJECT_NAME}
   src/terminal_node.cpp)
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
-target_link_libraries(${PROJECT_NAME} terminal readline)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies} terminal readline)
 
 install(TARGETS
   terminal
   ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -55,7 +54,7 @@ if(BUILD_TESTING)
   find_package(ament_index_cpp REQUIRED)
   find_package(lifecycle_msgs REQUIRED)
 
-  set(dependencies ${dependencies} ament_index_cpp lifecycle_msgs)
+  set(dependencies ${dependencies} ament_index_cpp::ament_index_cpp ${lifecycle_msgs_TARGETS})
 
   add_subdirectory(test)
 endif()

--- a/plansys2_terminal/test/CMakeLists.txt
+++ b/plansys2_terminal/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 ament_add_gtest(terminal_test terminal_test.cpp TIMEOUT 500)
-ament_target_dependencies(terminal_test ${dependencies})
-target_link_libraries(terminal_test terminal readline)
+target_link_libraries(terminal_test terminal readline ${dependencies})
 
 install(DIRECTORY
   pddl

--- a/plansys2_tests/CMakeLists.txt
+++ b/plansys2_tests/CMakeLists.txt
@@ -20,19 +20,19 @@ find_package(behaviortree_cpp REQUIRED)
 
 
 set(dependencies
-    rclcpp
-    rclcpp_lifecycle
-    lifecycle_msgs
-    rclcpp_cascade_lifecycle
-    rclcpp_action
-    plansys2_pddl_parser
-    ament_index_cpp
-    plansys2_msgs
-    plansys2_domain_expert
-    plansys2_problem_expert
-    plansys2_planner
-    plansys2_executor
-    behaviortree_cpp
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    rclcpp_cascade_lifecycle::rclcpp_cascade_lifecycle
+    rclcpp_action::rclcpp_action
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ament_index_cpp::ament_index_cpp
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_planner::plansys2_planner
+    plansys2_executor::plansys2_executor
+    behaviortree_cpp::behaviortree_cpp
+    ${plansys2_msgs_TARGETS}
+    ${lifecycle_msgs_TARGETS}
 )
 
 include_directories(include)
@@ -43,7 +43,7 @@ set(${PROJECT_NAME}_SOURCES
 )
 
 add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES})
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/plansys2_tools/CMakeLists.txt
+++ b/plansys2_tools/CMakeLists.txt
@@ -12,8 +12,15 @@ find_package(plansys2_problem_expert REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 
 
-
 set(dependencies
+  rclcpp::rclcpp
+  qt_gui_cpp::qt_gui_cpp
+  rqt_gui_cpp::rqt_gui_cpp
+  plansys2_problem_expert::plansys2_problem_expert
+  ${plansys2_msgs_TARGETS}
+)
+
+set(package_dependencies
   rclcpp
   plansys2_msgs
   qt_gui_cpp
@@ -26,11 +33,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(include)
 
 add_library(plansys2_logger SHARED src/plansys2_logger/LoggerNode.cpp)
-ament_target_dependencies(plansys2_logger ${dependencies})
+target_link_libraries(plansys2_logger PUBLIC ${dependencies})
 
 add_executable(logger src/logger.cpp)
-ament_target_dependencies(logger ${dependencies})
-target_link_libraries(logger plansys2_logger)
+target_link_libraries(logger PUBLIC ${dependencies} plansys2_logger)
 
 
 ## RQT Knowledge
@@ -66,11 +72,7 @@ add_library(rqt_plansys2_knowledge SHARED
   ${rqt_plansys2_knowledge_UIS_H}
 )
 
-target_link_libraries(
-  rqt_plansys2_knowledge
-  Qt5::Widgets
-)
-ament_target_dependencies(rqt_plansys2_knowledge ${dependencies})
+target_link_libraries(rqt_plansys2_knowledge PUBLIC ${dependencies} Qt5::Widgets)
 
 ## RQT Performers
 set(rqt_plansys2_performers_SRCS
@@ -105,11 +107,7 @@ add_library(rqt_plansys2_performers SHARED
   ${rqt_plansys2_performers_UIS_H}
 )
 
-target_link_libraries(
-  rqt_plansys2_performers
-  Qt5::Widgets
-)
-ament_target_dependencies(rqt_plansys2_performers ${dependencies})
+target_link_libraries(rqt_plansys2_performers PUBLIC ${dependencies} Qt5::Widgets)
 
 ## RQT Plan
 set(rqt_plansys2_plan_SRCS
@@ -144,11 +142,7 @@ add_library(rqt_plansys2_plan SHARED
   ${rqt_plansys2_plan_UIS_H}
 )
 
-target_link_libraries(
-  rqt_plansys2_plan
-  Qt5::Widgets
-)
-ament_target_dependencies(rqt_plansys2_plan ${dependencies})
+target_link_libraries(rqt_plansys2_plan PUBLIC ${dependencies} Qt5::Widgets)
 
 
 install(TARGETS
@@ -159,14 +153,14 @@ install(TARGETS
   EXPORT rqt_plansys2
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 install(PROGRAMS
   scripts/rqt_plansys2_knowledge
   scripts/rqt_plansys2_performers
   scripts/rqt_plansys2_plan
-  DESTINATION lib/${PROJECT_NAME}
+  DESTINATION bin
 )
 
 install(FILES plugin_knowledge.xml plugin_performers.xml plugin_plan.xml
@@ -184,5 +178,7 @@ pluginlib_export_plugin_description_file(rqt_gui "plugin_knowledge.xml")
 pluginlib_export_plugin_description_file(rqt_gui "plugin_performers.xml")
 pluginlib_export_plugin_description_file(rqt_gui "plugin_plan.xml")
 ament_export_libraries(rqt_plansys2)
+ament_export_targets(rqt_plansys2)
+ament_export_dependencies(${package_dependencies})
 
 ament_package()


### PR DESCRIPTION
Hi,

Some genius has removed `ament_target_dependencies`, so we have to fix all the CMake files.

Best