### PR TITLE
add behaviortree_cpp to dependency_repos.repos

### DIFF
--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           required-ros-distributions: rolling
       - name: Install test_msgs (provisional Fix)
-        run: sudo apt-get install ros-rolling-test-msgs
+        run: sudo apt-get install ros-rolling-test-msgs ros-rolling-rclcpp-cascade-lifecycle
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.3
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: ros-tooling/setup-ros@0.7.12
         with:
           required-ros-distributions: rolling
-      - name: Install BT.CPP v4 and test_msgs (provisional Fix)
-        run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
+      - name: Install test_msgs (provisional Fix)
+        run: sudo apt-get install ros-rolling-test-msgs
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.3
         with:

--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -10,4 +10,4 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: 793a6bdd75386a557382697dd2d7940351a6357d

--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -7,3 +7,7 @@ repositories:
     type: git
     url: https://github.com/fmrico/popf.git
     version: ros2
+  behaviortree_cpp:
+    type: git
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
CI is failing because `ros-rolling-behaviortree-cpp` is not being found. 