### PR TITLE
Fix ament deps deprecated

### DIFF
--- a/.github/workflows/jazzy-devel.yaml
+++ b/.github/workflows/jazzy-devel.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: ament_export_targets(export_${PROJECT_NAME})v4
+      - uses: actions/checkout@v4
         with:
           ref: jazzy-devel
       - name: Setup ROS 2

--- a/.github/workflows/jazzy-devel.yaml
+++ b/.github/workflows/jazzy-devel.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v4
+      - uses: ament_export_targets(export_${PROJECT_NAME})v4
         with:
           ref: jazzy-devel
       - name: Setup ROS 2

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.12
+        uses: ros-tooling/setup-ros@0.7.13
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -24,8 +24,6 @@ jobs:
         uses: ros-tooling/setup-ros@0.7.13
         with:
           required-ros-distributions: rolling
-      - name: Install BT.CPP v4 and test_msgs (provisional Fix)
-        run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.3
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.13
+        uses: ros-tooling/setup-ros
         with:
           required-ros-distributions: rolling
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.4.3
+        uses: ros-tooling/action-ros-ci
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
           target-ros2-distro: rolling

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4.2.3
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.13
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v4.2.3
+      - uses: actions/checkout@v4.2.2
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.13
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout
+      - uses: actions/checkout@v4.2.2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros
+        uses: ros-tooling/setup-ros@0.7.13
         with:
           required-ros-distributions: rolling
       - name: build and test
-        uses: ros-tooling/action-ros-ci
+        uses: ros-tooling/action-ros-ci@0.4.3
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
           target-ros2-distro: rolling

--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -7,3 +7,7 @@ repositories:
     type: git
     url: https://github.com/fmrico/popf.git
     version: ros2
+  behavior_tree_cpp:
+    type: git
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: 4.7.0

--- a/plansys2_bt_actions/CMakeLists.txt
+++ b/plansys2_bt_actions/CMakeLists.txt
@@ -58,7 +58,7 @@ install(
 
 install(TARGETS
   bt_action_node
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -87,7 +87,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -43,7 +43,7 @@ install(
 )
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -59,7 +59,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_domain_expert/CMakeLists.txt
+++ b/plansys2_domain_expert/CMakeLists.txt
@@ -69,7 +69,7 @@ install(
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -92,7 +92,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -118,7 +118,7 @@ pluginlib_export_plugin_description_file(plansys2_executor plugins.xml)
 install(DIRECTORY launch behavior_trees DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -151,6 +151,6 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME} bt_builder_plugins)
-ament_export_targets(${PROJECT_NAME} bt_builder_plugins)
+ament_export_targets(export_${PROJECT_NAME} bt_builder_plugins)
 ament_export_dependencies(${package_dependencies})
 ament_package()

--- a/plansys2_lifecycle_manager/CMakeLists.txt
+++ b/plansys2_lifecycle_manager/CMakeLists.txt
@@ -41,7 +41,7 @@ install(
 )
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -64,7 +64,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -60,7 +60,7 @@ install(
 )
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -84,7 +84,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -80,7 +80,7 @@ install(
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -103,7 +103,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_popf_plan_solver/CMakeLists.txt
+++ b/plansys2_popf_plan_solver/CMakeLists.txt
@@ -50,7 +50,7 @@ install(FILES plansys2_popf_plan_solver_plugin.xml
 )
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -66,7 +66,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()

--- a/plansys2_problem_expert/CMakeLists.txt
+++ b/plansys2_problem_expert/CMakeLists.txt
@@ -70,7 +70,7 @@ install(
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
-  ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -94,7 +94,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(${package_dependencies})
 
 ament_package()


### PR DESCRIPTION
Hi,

Update to fix the `ament_target_dependencies` deprecation:
* Change target name for exports
* Update action version