### PR TITLE
Modify export target. Rename metapackage

### DIFF
--- a/plansys2/CMakeLists.txt
+++ b/plansys2/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(ros2_planning_system)
+project(plansys2)
 
 find_package(ament_cmake REQUIRED)
 

--- a/plansys2/package.xml
+++ b/plansys2/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>ros2_planning_system</name>
+  <name>plansys2</name>
   <version>2.0.11</version>
 
   <description>ROS2 Planning System</description>

--- a/plansys2_bt_actions/CMakeLists.txt
+++ b/plansys2_bt_actions/CMakeLists.txt
@@ -48,7 +48,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -72,7 +72,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   rclcpp_action

--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -29,7 +29,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -45,7 +45,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   rclcpp_lifecycle

--- a/plansys2_domain_expert/CMakeLists.txt
+++ b/plansys2_domain_expert/CMakeLists.txt
@@ -56,7 +56,7 @@ install(DIRECTORY launch
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -78,7 +78,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   rclcpp_lifecycle

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -125,7 +125,7 @@ install(
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -153,7 +153,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME} bt_builder_plugins)
-ament_export_targets(${PROJECT_NAME} bt_builder_plugins)
+ament_export_targets(export_${PROJECT_NAME} bt_builder_plugins)
 ament_export_dependencies(
   eigen3_cmake_module
   Eigen3

--- a/plansys2_lifecycle_manager/CMakeLists.txt
+++ b/plansys2_lifecycle_manager/CMakeLists.txt
@@ -36,7 +36,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -57,7 +57,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   lifecycle_msgs

--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -53,7 +53,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -74,7 +74,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   plansys2_msgs
 )

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -61,7 +61,7 @@ install(DIRECTORY launch
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -83,7 +83,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   rclcpp_lifecycle

--- a/plansys2_popf_plan_solver/CMakeLists.txt
+++ b/plansys2_popf_plan_solver/CMakeLists.txt
@@ -35,7 +35,7 @@ install(FILES plansys2_popf_plan_solver_plugin.xml
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -52,7 +52,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   ament_index_cpp

--- a/plansys2_problem_expert/CMakeLists.txt
+++ b/plansys2_problem_expert/CMakeLists.txt
@@ -58,7 +58,7 @@ install(DIRECTORY launch
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -79,7 +79,7 @@ endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   rclcpp
   rclcpp_lifecycle


### PR DESCRIPTION
Hi,

This PR contains a slight modification in the export names, to be different from the library target, and a rename of the metapackage. Regarding packaging, it is better to be consistent with the names. 