### PR TITLE
Improvements on BTAction

### DIFF
--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -50,6 +50,15 @@ public:
   explicit BTAction(const std::string & action);
 
   /**
+   * @brief Constructor for the BTAction.
+   *
+   * @param[in] action Name of the action this executor handles.
+   * @param[in] rate Execution rate for the action.
+   */
+  [[deprecated("Use BTAction(const std::string & action) instead")]]
+  BTAction(const std::string & action, const std::chrono::nanoseconds & rate);
+
+  /**
    * @brief Get the name of the action.
    *
    * @return std::string The action name.

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -152,6 +152,9 @@ private:
   // The timeout value for waiting for a service to response
   std::chrono::milliseconds wait_for_service_timeout_;
 
+  // Duration for each iteration of BT execution
+  std::chrono::milliseconds bt_loop_duration_;
+
   // A regular, non-spinning ROS node that we can use for calls to the action client
   rclcpp::Node::SharedPtr client_node_;
 };

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -146,6 +146,12 @@ private:
   std::unique_ptr<BT::MinitraceLogger> bt_minitrace_logger_;
   // Groot2 monitor
   std::unique_ptr<BT::Groot2Publisher> groot_monitor_;
+
+  // Default timeout value while waiting for response from a server
+  std::chrono::milliseconds default_server_timeout_;
+
+  // A regular, non-spinning ROS node that we can use for calls to the action client
+  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace plansys2

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -150,6 +150,9 @@ private:
   // Default timeout value while waiting for response from a server
   std::chrono::milliseconds default_server_timeout_;
 
+  // The timeout value for waiting for a service to response
+  std::chrono::milliseconds wait_for_service_timeout_;
+
   // A regular, non-spinning ROS node that we can use for calls to the action client
   rclcpp::Node::SharedPtr client_node_;
 };

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -163,9 +163,6 @@ private:
 
   // Duration for each iteration of BT execution
   std::chrono::milliseconds bt_loop_duration_;
-
-  // A regular, non-spinning ROS node that we can use for calls to the action client
-  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace plansys2

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -46,9 +46,8 @@ public:
    * @brief Constructor for the BTAction.
    *
    * @param[in] action Name of the action this executor handles.
-   * @param[in] rate Execution rate for the action.
    */
-  explicit BTAction(const std::string & action, const std::chrono::nanoseconds & rate);
+  explicit BTAction(const std::string & action);
 
   /**
    * @brief Get the name of the action.

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -19,7 +19,9 @@
 #include <string>
 
 #include "behaviortree_cpp/action_node.h"
+#include "behaviortree_cpp/json_export.h"
 #include "plansys2_bt_actions/BTUtils.hpp"
+#include "plansys2_bt_actions/JSONUtils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -57,6 +57,8 @@ public:
 
     // Get the required items from the blackboard
     getInputOrBlackboard("server_timeout", server_timeout_);
+    wait_for_service_timeout_ =
+      config().blackboard->get<std::chrono::milliseconds>("wait_for_service_timeout");
 
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
@@ -89,13 +91,13 @@ public:
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
 
-    bool success_waiting = action_client_->wait_for_action_server(server_timeout_);
+    bool success_waiting = action_client_->wait_for_action_server(wait_for_service_timeout_);
 
     if (!success_waiting) {
       RCLCPP_ERROR(
         node_->get_logger(),
         "Timeout (%ld secs) waiting for \"%s\" action server",
-        server_timeout_.count() * 1000,
+        wait_for_service_timeout_.count() * 1000,
         action_name.c_str());
     }
 
@@ -447,6 +449,9 @@ protected:
   // The timeout value while waiting for response from a server when a
   // new action goal is sent or canceled
   std::chrono::milliseconds server_timeout_;
+
+  // The timeout value for waiting for a service to response
+  std::chrono::milliseconds wait_for_service_timeout_;
 
   static const int IDLE = 0;
   static const int GOAL_SENT = 1;

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "behaviortree_cpp/action_node.h"
+#include "plansys2_bt_actions/BTUtils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -55,7 +56,7 @@ public:
     }
 
     // Get the required items from the blackboard
-    server_timeout_ = 5s;
+    getInputOrBlackboard("server_timeout", server_timeout_);
 
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
@@ -194,15 +195,6 @@ public:
           RCLCPP_DEBUG(node_->get_logger(), "%s IDLE", node_->get_name());
           assert((status() == BT::NodeStatus::IDLE));
 
-          double server_timeout = 5.0;
-          if (!getInput("server_timeout", server_timeout)) {
-            RCLCPP_INFO(
-              node_->get_logger(),
-              "Missing input port [server_timeout], "
-              "using default value of 5s");
-          }
-          server_timeout_ = std::chrono::milliseconds(static_cast<int>(server_timeout * 1000.0));
-
           if (!createActionClient(action_name_)) {
             RCLCPP_ERROR(node_->get_logger(), "Failed to create action client");
             return BT::NodeStatus::FAILURE;
@@ -231,8 +223,7 @@ public:
             if (!goal_handle_) {
               RCLCPP_ERROR(
                 node_->get_logger(),
-                "Goal was rejected by action server %s",
-                action_name_.c_str());
+                "Goal was rejected by action server %s", action_name_.c_str());
               state_ = GOAL_FAILURE;
               return BT::NodeStatus::FAILURE;
             } else {
@@ -243,8 +234,7 @@ public:
             if ((node_->now() - goal_sent_ts_) > server_timeout_) {
               RCLCPP_ERROR(
                 node_->get_logger(),
-                "Failed to send goal to action server %s",
-                action_name_.c_str());
+                "Failed to send goal to action server %s", action_name_.c_str());
               state_ = GOAL_FAILURE;
               return BT::NodeStatus::FAILURE;
             } else {
@@ -452,7 +442,7 @@ protected:
   typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult result_;
 
   // The node that will be used for any ROS operations
-  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_;
 
   // The timeout value while waiting for response from a server when a
   // new action goal is sent or canceled

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -444,7 +444,7 @@ protected:
   typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult result_;
 
   // The node that will be used for any ROS operations
-  rclcpp::Node::SharedPtr node_;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
 
   // The timeout value while waiting for response from a server when a
   // new action goal is sent or canceled

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
@@ -286,6 +286,6 @@ protected:
   bool should_send_request_;
 };
 
-}  // namespace nav2_behavior_tree
+}  // namespace plansys2
 
-#endif  // NAV2_BEHAVIOR_TREE__BT_SERVICE_NODE_HPP_
+#endif  // PLANSYS2_BT_ACTIONS__BTSERVICENODE_HPP_

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
@@ -113,8 +113,15 @@ public:
     if (service_new != service_name_ || !service_client_) {
       service_name_ = service_new;
       node_ = config().blackboard->template get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
-      service_client_ =
-        node_->create_client<ServiceT>(service_name_);
+
+      callback_group_ = node_->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+      callback_group_executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      callback_group_executor_->add_callback_group(
+        callback_group_, node_->get_node_base_interface());
+      service_client_ = node_->create_client<ServiceT>(
+        service_name_, rclcpp::ServicesQoS(), callback_group_);
     }
   }
 
@@ -169,7 +176,7 @@ public:
         return BT::NodeStatus::FAILURE;
       }
 
-      future_result_ = service_client_->async_send_request(request_).future;
+      future_result_ = service_client_->async_send_request(request_).share();
       sent_time_ = node_->now();
       request_sent_ = true;
     }
@@ -216,8 +223,7 @@ public:
     if (remaining > std::chrono::milliseconds(0)) {
       auto timeout = remaining > max_timeout_ ? max_timeout_ : remaining;
 
-      rclcpp::FutureReturnCode rc;
-      rc = rclcpp::spin_until_future_complete(node_, future_result_, timeout);
+      auto rc = callback_group_executor_->spin_until_future_complete(future_result_, timeout);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
         request_sent_ = false;
         BT::NodeStatus status = on_completion(future_result_.get());
@@ -266,6 +272,8 @@ protected:
 
   // The node that will be used for any ROS operations
   rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr callback_group_executor_;
 
   // The timeout value while to use in the tick loop while waiting for
   // a result from the server

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTServiceNode.hpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2019 Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_BT_ACTIONS__BTSERVICENODE_HPP_
+#define PLANSYS2_BT_ACTIONS__BTSERVICENODE_HPP_
+
+#include <string>
+#include <memory>
+#include <chrono>
+
+#include "behaviortree_cpp/action_node.h"
+#include "behaviortree_cpp/json_export.h"
+#include "plansys2_bt_actions/BTUtils.hpp"
+#include "plansys2_bt_actions/JSONUtils.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+namespace plansys2
+{
+
+using namespace std::chrono_literals;  // NOLINT
+
+/**
+ * @brief Abstract class representing a service based BT node
+ * @tparam ServiceT Type of service
+ * @note This is an Asynchronous (long-running) node which may return a RUNNING state while executing.
+ *       It will re-initialize when halted.
+ */
+template<class ServiceT>
+class BtServiceNode : public BT::ActionNodeBase
+{
+public:
+  /**
+   * @brief A nav2_behavior_tree::BtServiceNode constructor
+   * @param service_node_name BT node name
+   * @param conf BT node configuration
+   * @param service_name Optional service name this node creates a client for instead of from input port
+   */
+  BtServiceNode(
+    const std::string & service_node_name,
+    const BT::NodeConfiguration & conf,
+    const std::string & service_name = "")
+  : BT::ActionNodeBase(service_node_name, conf), service_name_(service_name), service_node_name_(
+      service_node_name)
+  {
+    initialize();
+
+    // Make a request for the service without parameter
+    request_ = std::make_shared<typename ServiceT::Request>();
+
+    // Make sure the server is actually there before continuing
+    RCLCPP_DEBUG(
+      node_->get_logger(), "Waiting for \"%s\" service",
+      service_name_.c_str());
+    if (!service_client_->wait_for_service(wait_for_service_timeout_)) {
+      RCLCPP_ERROR(
+        node_->get_logger(), "\"%s\" service server not available after waiting for %.2fs",
+        service_name_.c_str(), wait_for_service_timeout_.count() / 1000.0);
+      throw std::runtime_error(
+              std::string(
+                "Service server %s not available",
+                service_name_.c_str()));
+    }
+
+    RCLCPP_DEBUG(
+      node_->get_logger(), "\"%s\" BtServiceNode initialized",
+      service_node_name_.c_str());
+  }
+
+  BtServiceNode() = delete;
+
+  virtual ~BtServiceNode()
+  {
+  }
+
+  /**
+   * @brief Function to read parameters and initialize class variables
+   */
+  void initialize()
+  {
+    // Get the required items from the blackboard
+    auto bt_loop_duration =
+      config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
+    getInputOrBlackboard("server_timeout", server_timeout_);
+    wait_for_service_timeout_ =
+      config().blackboard->template get<std::chrono::milliseconds>("wait_for_service_timeout");
+
+    // timeout should be less than bt_loop_duration to be able to finish the current tick
+    max_timeout_ = std::chrono::duration_cast<std::chrono::milliseconds>(bt_loop_duration * 0.5);
+
+    // Now that we have node_ to use, create the service client for this BT service
+    createROSInterfaces();
+  }
+
+  /**
+   * @brief Function to create ROS interfaces
+   */
+  void createROSInterfaces()
+  {
+    std::string service_new;
+    getInput("service_name", service_new);
+    if (service_new != service_name_ || !service_client_) {
+      service_name_ = service_new;
+      node_ = config().blackboard->template get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
+      service_client_ =
+        node_->create_client<ServiceT>(service_name_);
+    }
+  }
+
+  /**
+   * @brief Any subclass of BtServiceNode that accepts parameters must provide a
+   * providedPorts method and call providedBasicPorts in it.
+   * @param addition Additional ports to add to BT port list
+   * @return BT::PortsList Containing basic ports along with node-specific ports
+   */
+  static BT::PortsList providedBasicPorts(BT::PortsList addition)
+  {
+    BT::PortsList basic = {
+      BT::InputPort<std::string>("service_name", "please_set_service_name_in_BT_Node"),
+      BT::InputPort<std::chrono::milliseconds>("server_timeout")
+    };
+    basic.insert(addition.begin(), addition.end());
+
+    return basic;
+  }
+
+  /**
+   * @brief Creates list of BT ports
+   * @return BT::PortsList Containing basic ports along with node-specific ports
+   */
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({});
+  }
+
+  /**
+   * @brief The main override required by a BT service
+   * @return BT::NodeStatus Status of tick execution
+   */
+  BT::NodeStatus tick() override
+  {
+    if (!BT::isStatusActive(status())) {
+      initialize();
+    }
+
+    if (!request_sent_) {
+      // reset the flag to send the request or not,
+      // allowing the user the option to set it in on_tick
+      should_send_request_ = true;
+
+      // Clear the input request to make sure we have no leftover from previous calls
+      request_ = std::make_shared<typename ServiceT::Request>();
+
+      // user defined callback, may modify "should_send_request_".
+      on_tick();
+
+      if (!should_send_request_) {
+        return BT::NodeStatus::FAILURE;
+      }
+
+      future_result_ = service_client_->async_send_request(request_).future;
+      sent_time_ = node_->now();
+      request_sent_ = true;
+    }
+    return check_future();
+  }
+
+  /**
+   * @brief The other (optional) override required by a BT service.
+   */
+  void halt() override
+  {
+    request_sent_ = false;
+    resetStatus();
+  }
+
+  /**
+   * @brief Function to perform some user-defined operation on tick
+   * Fill in service request with information if necessary
+   */
+  virtual void on_tick()
+  {
+  }
+
+  /**
+   * @brief Function to perform some user-defined operation upon successful
+   * completion of the service. Could put a value on the blackboard.
+   * @param response can be used to get the result of the service call in the BT Node.
+   * @return BT::NodeStatus Returns SUCCESS by default, user may override to return another value
+   */
+  virtual BT::NodeStatus on_completion(std::shared_ptr<typename ServiceT::Response>/*response*/)
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  /**
+   * @brief Check the future and decide the status of BT
+   * @return BT::NodeStatus SUCCESS if future complete before timeout, FAILURE otherwise
+   */
+  virtual BT::NodeStatus check_future()
+  {
+    auto elapsed = (node_->now() - sent_time_).template to_chrono<std::chrono::milliseconds>();
+    auto remaining = server_timeout_ - elapsed;
+
+    if (remaining > std::chrono::milliseconds(0)) {
+      auto timeout = remaining > max_timeout_ ? max_timeout_ : remaining;
+
+      rclcpp::FutureReturnCode rc;
+      rc = rclcpp::spin_until_future_complete(node_, future_result_, timeout);
+      if (rc == rclcpp::FutureReturnCode::SUCCESS) {
+        request_sent_ = false;
+        BT::NodeStatus status = on_completion(future_result_.get());
+        return status;
+      }
+
+      if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+        on_wait_for_result();
+        elapsed = (node_->now() - sent_time_).template to_chrono<std::chrono::milliseconds>();
+        if (elapsed < server_timeout_) {
+          return BT::NodeStatus::RUNNING;
+        }
+      }
+    }
+
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Node timed out while executing service call to %s.", service_name_.c_str());
+    request_sent_ = false;
+    return BT::NodeStatus::FAILURE;
+  }
+
+  /**
+   * @brief Function to perform some user-defined operation after a timeout waiting
+   * for a result that hasn't been received yet
+   */
+  virtual void on_wait_for_result()
+  {
+  }
+
+protected:
+  /**
+   * @brief Function to increment recovery count on blackboard if this node wraps a recovery
+   */
+  void increment_recovery_count()
+  {
+    int recovery_count = 0;
+    [[maybe_unused]] auto res = config().blackboard->get("number_recoveries", recovery_count);  // NOLINT
+    recovery_count += 1;
+    config().blackboard->set("number_recoveries", recovery_count);  // NOLINT
+  }
+
+  std::string service_name_, service_node_name_;
+  typename rclcpp::Client<ServiceT>::SharedPtr service_client_;
+  std::shared_ptr<typename ServiceT::Request> request_;
+
+  // The node that will be used for any ROS operations
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
+
+  // The timeout value while to use in the tick loop while waiting for
+  // a result from the server
+  std::chrono::milliseconds server_timeout_;
+
+  // The timeout value for BT loop execution
+  std::chrono::milliseconds max_timeout_;
+
+  // The timeout value for waiting for a service to response
+  std::chrono::milliseconds wait_for_service_timeout_;
+
+  // To track the server response when a new request is sent
+  std::shared_future<typename ServiceT::Response::SharedPtr> future_result_;
+  bool request_sent_{false};
+  rclcpp::Time sent_time_;
+
+  // Can be set in on_tick or on_wait_for_result to indicate if a request should be sent.
+  bool should_send_request_;
+};
+
+}  // namespace nav2_behavior_tree
+
+#endif  // NAV2_BEHAVIOR_TREE__BT_SERVICE_NODE_HPP_

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTUtils.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTUtils.hpp
@@ -23,6 +23,24 @@ namespace BT
 {
 
 /**
+ * @brief Parse XML string to std::chrono::milliseconds
+ * @param key XML string
+ * @return std::chrono::milliseconds
+ */
+template<>
+inline std::chrono::milliseconds convertFromString<std::chrono::milliseconds>(const StringView key)
+{
+  // if string starts with "json:{", try to parse it as json
+  if (StartWith(key, "json:")) {
+    auto new_key = key;
+    new_key.remove_prefix(5);
+    return convertFromJSON<std::chrono::milliseconds>(new_key);
+  }
+
+  return std::chrono::milliseconds(std::stoul(key.data()));
+}
+
+/**
  * @brief Try reading an import port first, and if that doesn't work
  * fallback to reading directly the blackboard.
  * The blackboard must be passed explicitly because config() is private in BT.CPP 4.X

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTUtils.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTUtils.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 Davide Faconti
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_BT_ACTIONS__BTUTILS_HPP_
+#define PLANSYS2_BT_ACTIONS__BTUTILS_HPP_
+
+#include <string>
+
+#include "behaviortree_cpp/behavior_tree.h"
+
+namespace BT
+{
+
+/**
+ * @brief Try reading an import port first, and if that doesn't work
+ * fallback to reading directly the blackboard.
+ * The blackboard must be passed explicitly because config() is private in BT.CPP 4.X
+ *
+ * @param bt_node node
+ * @param blackboard the blackboard obtained with node->config().blackboard
+ * @param param_name std::string
+ * @param behavior_tree_node the node
+ * @return <T>
+ */
+template<typename T> inline
+bool getInputPortOrBlackboard(
+  const BT::TreeNode & bt_node,
+  const BT::Blackboard & blackboard,
+  const std::string & param_name,
+  T & value)
+{
+  if (bt_node.getInput<T>(param_name, value)) {
+    return true;
+  }
+  if (blackboard.get<T>(param_name, value)) {
+    return true;
+  }
+  return false;
+}
+
+// Macro to remove boiler plate when using getInputPortOrBlackboard
+#define getInputOrBlackboard(name, value) \
+  getInputPortOrBlackboard(*this, *(this->config().blackboard), name, value);
+
+}  // namespace BT
+
+#endif  // PLANSYS2_BT_ACTIONS__BTUTILS_HPP_

--- a/plansys2_bt_actions/include/plansys2_bt_actions/JSONUtils.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/JSONUtils.hpp
@@ -46,4 +46,24 @@ BT_JSON_CONVERTER(std_msgs::msg::Header, msg)
 
 }  // namespace std_msgs::msg
 
+namespace std
+{
+
+inline void from_json(const nlohmann::json & js, std::chrono::milliseconds & dest)
+{
+  if (js.contains("ms")) {
+    dest = std::chrono::milliseconds(js.at("ms").get<int>());
+  } else {
+    throw std::runtime_error("Invalid JSON for std::chrono::milliseconds");
+  }
+}
+
+inline void to_json(nlohmann::json & js, const std::chrono::milliseconds & src)
+{
+  js["__type"] = "std::chrono::milliseconds";
+  js["ms"] = src.count();
+}
+
+}  // namespace std
+
 #endif  // PLANSYS2_BT_ACTIONS__JSONUTILS_HPP_

--- a/plansys2_bt_actions/src/bt_action_node.cpp
+++ b/plansys2_bt_actions/src/bt_action_node.cpp
@@ -26,10 +26,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto action_node = std::make_shared<plansys2::BTAction>(
-    "default",
-    200ms  // ToDo(fmrico): This should be specified by a parameter
-  );
+  auto action_node = std::make_shared<plansys2::BTAction>("default");
 
   action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
 

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -79,11 +79,11 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   blackboard_ = BT::Blackboard::create();
 
   // Put items in the blackboard
-  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
+  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
   blackboard_->set<std::chrono::milliseconds>(
     "wait_for_service_timeout", wait_for_service_timeout_);
-  blackboard_->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);
 
   return ActionExecutorClient::on_configure(previous_state);
 }

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -85,14 +85,11 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
     factory_.registerFromPlugin(loader.getOSName(plugin));
   }
 
-  // Create a regular, non-spinning ROS node that we can use for calls to the action client
-  client_node_ = std::make_shared<rclcpp::Node>("_");
-
   // Create the blackboard that will be shared by all of the nodes in the tree
   blackboard_ = BT::Blackboard::create();
 
   // Put items in the blackboard
-  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);
+  blackboard_->set<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node", shared_from_this());
   blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
   blackboard_->set<std::chrono::milliseconds>(
     "wait_for_service_timeout", wait_for_service_timeout_);
@@ -104,7 +101,6 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 BTAction::on_cleanup(const rclcpp_lifecycle::State & previous_state)
 {
-  client_node_.reset();
   plugin_list_.clear();
   blackboard_.reset();
   return ActionExecutorClient::on_cleanup(previous_state);

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -40,6 +40,7 @@ BTAction::BTAction(const std::string & action, const std::chrono::nanoseconds & 
   declare_parameter<bool>("bt_minitrace_logging", false);
   declare_parameter<bool>("enable_groot_monitoring", false);
   declare_parameter<int>("server_port", -1);
+  declare_parameter<int>("server_timeout", 20);
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -56,14 +57,25 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
     RCLCPP_INFO_STREAM(get_logger(), "plugin: [" << plugin << "]");
   }
 
+  int default_server_timeout;
+  get_parameter("server_timeout", default_server_timeout);
+  default_server_timeout_ = std::chrono::milliseconds(default_server_timeout);
+
   BT::SharedLibrary loader;
 
   for (auto plugin : plugin_lib_names) {
     factory_.registerFromPlugin(loader.getOSName(plugin));
   }
 
+  // Create a regular, non-spinning ROS node that we can use for calls to the action client
+  client_node_ = std::make_shared<rclcpp::Node>(action_);
+
+  // Create the blackboard that will be shared by all of the nodes in the tree
   blackboard_ = BT::Blackboard::create();
-  blackboard_->set("node", shared_from_this());
+
+  // Put items in the blackboard
+  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
 
   return ActionExecutorClient::on_configure(previous_state);
 }
@@ -71,6 +83,9 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 BTAction::on_cleanup(const rclcpp_lifecycle::State & previous_state)
 {
+  client_node_.reset();
+  plugin_list_.clear();
+  blackboard_.reset();
   return ActionExecutorClient::on_cleanup(previous_state);
 }
 

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -41,6 +41,7 @@ BTAction::BTAction(const std::string & action, const std::chrono::nanoseconds & 
   declare_parameter<bool>("enable_groot_monitoring", false);
   declare_parameter<int>("server_port", -1);
   declare_parameter<int>("server_timeout", 20);
+  declare_parameter<int>("wait_for_service_timeout", 1000);
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -60,6 +61,9 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   int default_server_timeout;
   get_parameter("server_timeout", default_server_timeout);
   default_server_timeout_ = std::chrono::milliseconds(default_server_timeout);
+  int wait_for_service_timeout;
+  get_parameter("wait_for_service_timeout", wait_for_service_timeout);
+  wait_for_service_timeout_ = std::chrono::milliseconds(wait_for_service_timeout);
 
   BT::SharedLibrary loader;
 
@@ -76,6 +80,8 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   // Put items in the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>(
+    "wait_for_service_timeout", wait_for_service_timeout_);
 
   return ActionExecutorClient::on_configure(previous_state);
 }

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -73,7 +73,7 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   }
 
   // Create a regular, non-spinning ROS node that we can use for calls to the action client
-  client_node_ = std::make_shared<rclcpp::Node>(action_);
+  client_node_ = std::make_shared<rclcpp::Node>("_");
 
   // Create the blackboard that will be shared by all of the nodes in the tree
   blackboard_ = BT::Blackboard::create();

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -44,6 +44,19 @@ BTAction::BTAction(const std::string & action)
   declare_parameter<int>("wait_for_service_timeout", 1000);
 }
 
+BTAction::BTAction(const std::string & action, const std::chrono::nanoseconds & rate)
+: ActionExecutorClient(action, rate)
+{
+  declare_parameter<std::string>("bt_xml_file", "");
+  declare_parameter<std::vector<std::string>>("plugins", std::vector<std::string>({}));
+  declare_parameter<bool>("bt_file_logging", false);
+  declare_parameter<bool>("bt_minitrace_logging", false);
+  declare_parameter<bool>("enable_groot_monitoring", false);
+  declare_parameter<int>("server_port", -1);
+  declare_parameter<int>("server_timeout", 20);
+  declare_parameter<int>("wait_for_service_timeout", 1000);
+}
+
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
 {

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -31,8 +31,8 @@
 namespace plansys2
 {
 
-BTAction::BTAction(const std::string & action, const std::chrono::nanoseconds & rate)
-: ActionExecutorClient(action, rate)
+BTAction::BTAction(const std::string & action)
+: ActionExecutorClient(action)
 {
   declare_parameter<std::string>("bt_xml_file", "");
   declare_parameter<std::vector<std::string>>("plugins", std::vector<std::string>({}));

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -64,6 +64,7 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   int wait_for_service_timeout;
   get_parameter("wait_for_service_timeout", wait_for_service_timeout);
   wait_for_service_timeout_ = std::chrono::milliseconds(wait_for_service_timeout);
+  bt_loop_duration_ = std::chrono::duration_cast<std::chrono::milliseconds>(period_);
 
   BT::SharedLibrary loader;
 
@@ -82,6 +83,7 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>(
     "wait_for_service_timeout", wait_for_service_timeout_);
+  blackboard_->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);  // NOLINT
 
   return ActionExecutorClient::on_configure(previous_state);
 }

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -26,6 +26,7 @@
 #include "behaviortree_cpp/utils/shared_library.h"
 #include "std_msgs/msg/header.hpp"
 #include "plansys2_bt_actions/BTAction.hpp"
+#include "plansys2_bt_actions/BTUtils.hpp"
 #include "plansys2_bt_actions/JSONUtils.hpp"
 
 namespace plansys2

--- a/plansys2_bt_actions/test/behavior_tree/Move.cpp
+++ b/plansys2_bt_actions/test/behavior_tree/Move.cpp
@@ -32,7 +32,7 @@ Move::Move(
   const BT::NodeConfig & conf)
 : plansys2::BtActionNode<test_msgs::action::Fibonacci>(xml_tag_name, action_name, conf)
 {
-  rclcpp_lifecycle::LifecycleNode::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
   if (!config().blackboard->get("node", node)) {
     RCLCPP_ERROR(node_->get_logger(), "Failed to get 'node' from the blackboard");
   }

--- a/plansys2_bt_actions/test/behavior_tree/Move.cpp
+++ b/plansys2_bt_actions/test/behavior_tree/Move.cpp
@@ -32,7 +32,7 @@ Move::Move(
   const BT::NodeConfig & conf)
 : plansys2::BtActionNode<test_msgs::action::Fibonacci>(xml_tag_name, action_name, conf)
 {
-  rclcpp::Node::SharedPtr node;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node;
   if (!config().blackboard->get("node", node)) {
     RCLCPP_ERROR(node_->get_logger(), "Failed to get 'node' from the blackboard");
   }

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -150,8 +150,11 @@ TEST_F(BTActionsTestCase, load_plugins)
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_bt_actions");
   std::string xml_file = pkgpath + "/test/behavior_tree/transport.xml";
 
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto blackboard = BT::Blackboard::create();
-  blackboard->set("node", node);
+  blackboard->set("node", client_node);
+  blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   BT::Tree tree = factory.createTreeFromFile(xml_file, blackboard);
 
   rclcpp::Rate rate(10);
@@ -187,8 +190,11 @@ TEST_F(BTActionsTestCase, on_tick_failure)
 
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnTickFail>(config);
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto bb = BT::Blackboard::create();
-  bb->set("node", node);
+  bb->set("node", client_node);
+  bb->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  bb->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   config.blackboard = bb;
 
   plansys2_bt_tests::OnTickFail failure_node("OnTickFail", "move", config);
@@ -228,8 +234,11 @@ TEST_F(BTActionsTestCase, on_feedback_failure)
 
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnFeedbackFail>(config);
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto bb = BT::Blackboard::create();
-  bb->set("node", node);
+  bb->set("node", client_node);
+  bb->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  bb->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   config.blackboard = bb;
 
   plansys2_bt_tests::OnFeedbackFail failure_node("OnFeedbackFail",

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -126,7 +126,6 @@ protected:
 
 TEST_F(BTActionsTestCase, load_plugins)
 {
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("load_plugins_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
@@ -136,7 +135,6 @@ TEST_F(BTActionsTestCase, load_plugins)
       rclcpp::Rate rate(100);
       while (!finish) {
         rclcpp::spin_some(move_server_node);
-        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -153,7 +151,7 @@ TEST_F(BTActionsTestCase, load_plugins)
   std::string xml_file = pkgpath + "/test/behavior_tree/transport.xml";
 
   auto blackboard = BT::Blackboard::create();
-  blackboard->set("node", client_node);
+  blackboard->set("node", node);
   blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
   blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   BT::Tree tree = factory.createTreeFromFile(xml_file, blackboard);
@@ -175,7 +173,6 @@ TEST_F(BTActionsTestCase, load_plugins)
 TEST_F(BTActionsTestCase, on_tick_failure)
 {
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
 
@@ -184,7 +181,6 @@ TEST_F(BTActionsTestCase, on_tick_failure)
       rclcpp::Rate rate(100);
       while (!finished) {
         rclcpp::spin_some(move_server_node);
-        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -194,7 +190,7 @@ TEST_F(BTActionsTestCase, on_tick_failure)
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnTickFail>(config);
   auto bb = BT::Blackboard::create();
-  bb->set("node", client_node);
+  bb->set("node", node);
   bb->set<std::chrono::milliseconds>("server_timeout", 20ms);
   bb->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   config.blackboard = bb;
@@ -221,7 +217,6 @@ TEST_F(BTActionsTestCase, on_tick_failure)
 TEST_F(BTActionsTestCase, on_feedback_failure)
 {
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
 
@@ -230,7 +225,6 @@ TEST_F(BTActionsTestCase, on_feedback_failure)
       rclcpp::Rate rate(100);
       while (!finished) {
         rclcpp::spin_some(move_server_node);
-        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -239,7 +233,7 @@ TEST_F(BTActionsTestCase, on_feedback_failure)
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnFeedbackFail>(config);
   auto bb = BT::Blackboard::create();
-  bb->set("node", client_node);
+  bb->set("node", node);
   bb->set<std::chrono::milliseconds>("server_timeout", 20ms);
   bb->set<std::chrono::milliseconds>("wait_for_service_timeout", 10ms);
   config.blackboard = bb;

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -261,12 +261,13 @@ TEST_F(BTActionsTestCase, bt_action)
   std::vector<std::string> plugins = {
     "plansys2_close_gripper_bt_node", "plansys2_open_gripper_bt_node"};
 
-  auto bt_action = std::make_shared<plansys2::BTAction>("assemble", 100ms);
+  auto bt_action = std::make_shared<plansys2::BTAction>("assemble");
 
   auto lc_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
   auto action_client = plansys2::ActionExecutor::make_shared("(assemble r2d2 z p1 p2 p3)", lc_node);
 
   bt_action->set_parameter(rclcpp::Parameter("action_name", "assemble"));
+  bt_action->set_parameter(rclcpp::Parameter("rate", 10.0));
   bt_action->set_parameter(rclcpp::Parameter("bt_xml_file", xml_file));
   bt_action->set_parameter(rclcpp::Parameter("plugins", plugins));
 
@@ -300,12 +301,13 @@ TEST_F(BTActionsTestCase, cancel_bt_action)
   std::vector<std::string> plugins = {
     "plansys2_close_gripper_bt_node", "plansys2_open_gripper_bt_node"};
 
-  auto bt_action = std::make_shared<plansys2::BTAction>("assemble", 1s);
+  auto bt_action = std::make_shared<plansys2::BTAction>("assemble");
 
   auto lc_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
   auto action_client = plansys2::ActionExecutor::make_shared("(assemble r2d2 z p1 p2 p3)", lc_node);
 
   bt_action->set_parameter(rclcpp::Parameter("action_name", "assemble"));
+  bt_action->set_parameter(rclcpp::Parameter("rate", 1.0));
   bt_action->set_parameter(rclcpp::Parameter("bt_xml_file", xml_file));
   bt_action->set_parameter(rclcpp::Parameter("plugins", plugins));
 

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -126,6 +126,7 @@ protected:
 
 TEST_F(BTActionsTestCase, load_plugins)
 {
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("load_plugins_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
@@ -135,6 +136,7 @@ TEST_F(BTActionsTestCase, load_plugins)
       rclcpp::Rate rate(100);
       while (!finish) {
         rclcpp::spin_some(move_server_node);
+        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -150,7 +152,6 @@ TEST_F(BTActionsTestCase, load_plugins)
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_bt_actions");
   std::string xml_file = pkgpath + "/test/behavior_tree/transport.xml";
 
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto blackboard = BT::Blackboard::create();
   blackboard->set("node", client_node);
   blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
@@ -174,6 +175,7 @@ TEST_F(BTActionsTestCase, load_plugins)
 TEST_F(BTActionsTestCase, on_tick_failure)
 {
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
 
@@ -182,6 +184,7 @@ TEST_F(BTActionsTestCase, on_tick_failure)
       rclcpp::Rate rate(100);
       while (!finished) {
         rclcpp::spin_some(move_server_node);
+        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -190,7 +193,6 @@ TEST_F(BTActionsTestCase, on_tick_failure)
 
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnTickFail>(config);
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto bb = BT::Blackboard::create();
   bb->set("node", client_node);
   bb->set<std::chrono::milliseconds>("server_timeout", 20ms);
@@ -219,6 +221,7 @@ TEST_F(BTActionsTestCase, on_tick_failure)
 TEST_F(BTActionsTestCase, on_feedback_failure)
 {
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto client_node = rclcpp::Node::make_shared("client_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
 
@@ -227,6 +230,7 @@ TEST_F(BTActionsTestCase, on_feedback_failure)
       rclcpp::Rate rate(100);
       while (!finished) {
         rclcpp::spin_some(move_server_node);
+        rclcpp::spin_some(client_node);
         rclcpp::spin_some(node->get_node_base_interface());
         rate.sleep();
       }
@@ -234,7 +238,6 @@ TEST_F(BTActionsTestCase, on_feedback_failure)
 
   BT::NodeConfig config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnFeedbackFail>(config);
-  auto client_node = rclcpp::Node::make_shared("client_node");
   auto bb = BT::Blackboard::create();
   bb->set("node", client_node);
   bb->set<std::chrono::milliseconds>("server_timeout", 20ms);

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -305,6 +305,45 @@ TEST_F(BTActionsTestCase, bt_action)
   lc_node->shutdown();
 }
 
+TEST_F(BTActionsTestCase, bt_action_old_constructor)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_bt_actions");
+  std::string xml_file = pkgpath + "/test/behavior_tree/assemble.xml";
+
+  std::vector<std::string> plugins = {
+    "plansys2_close_gripper_bt_node", "plansys2_open_gripper_bt_node"};
+
+  auto bt_action = std::make_shared<plansys2::BTAction>("assemble", 100ms);
+
+  auto lc_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto action_client = plansys2::ActionExecutor::make_shared("(assemble r2d2 z p1 p2 p3)", lc_node);
+
+  bt_action->set_parameter(rclcpp::Parameter("action_name", "assemble"));
+  bt_action->set_parameter(rclcpp::Parameter("bt_xml_file", xml_file));
+  bt_action->set_parameter(rclcpp::Parameter("plugins", plugins));
+
+  bt_action->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  rclcpp::experimental::executors::EventsExecutor exe;
+  exe.add_node(bt_action->get_node_base_interface());
+  exe.add_node(lc_node->get_node_base_interface());
+
+  bool finished = false;
+  while (rclcpp::ok && !finished) {
+    exe.spin_some();
+
+    action_client->tick(lc_node->now());
+    finished = action_client->get_status() == BT::NodeStatus::SUCCESS;
+  }
+
+  auto start = lc_node->now();
+  while ( (lc_node->now() - start).seconds() < 2) {
+    exe.spin_some();
+  }
+
+  lc_node->shutdown();
+}
+
 TEST_F(BTActionsTestCase, cancel_bt_action)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_bt_actions");

--- a/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
@@ -49,21 +49,19 @@ public:
    * @brief Factory method to create a shared pointer to an ActionExecutorClient.
    *
    * @param[in] node_name Name for the ROS node.
-   * @param[in] rate Execution rate for the action.
    * @return Shared pointer to the newly created ActionExecutorClient.
    */
-  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<ActionExecutorClient>(node_name, rate);
+    return std::make_shared<ActionExecutorClient>(node_name);
   }
 
   /**
    * @brief Constructor for the ActionExecutorClient.
    *
    * @param[in] node_name Name for the ROS node.
-   * @param[in] rate Execution rate for periodic work.
    */
-  ActionExecutorClient(const std::string & node_name, const std::chrono::nanoseconds & rate);
+  ActionExecutorClient(const std::string & node_name);
 
   /**
    * @brief Get the time when the action execution started.
@@ -182,9 +180,10 @@ protected:
    */
   void finish(bool success, float completion, const std::string & status = "");
 
-  std::chrono::nanoseconds rate_;
+  // Period for the timer to call do_work
+  std::chrono::nanoseconds period_;
   std::string action_managed_;
-  bool commited_;
+  bool committed_;
 
   std::vector<std::string> current_arguments_;
   std::vector<std::string> specialized_arguments_;

--- a/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
@@ -61,7 +61,7 @@ public:
    *
    * @param[in] node_name Name for the ROS node.
    */
-  ActionExecutorClient(const std::string & node_name);
+  explicit ActionExecutorClient(const std::string & node_name);
 
   /**
    * @brief Get the time when the action execution started.

--- a/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
@@ -32,6 +32,9 @@
 namespace plansys2
 {
 
+using CallbackReturnT =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
 /**
  * @class plansys2::ActionExecutorClient
  * @brief Base class for implementing action executors in the planning system.
@@ -62,6 +65,15 @@ public:
    * @param[in] node_name Name for the ROS node.
    */
   explicit ActionExecutorClient(const std::string & node_name);
+
+  /**
+   * @brief Constructor for the ActionExecutorClient.
+   *
+   * @param[in] node_name Name for the ROS node.
+   * @param[in] rate Execution rate for periodic work.
+   */
+  [[deprecated("Use ActionExecutorClient(const std::string & node_name) instead")]]
+  ActionExecutorClient(const std::string & node_name, const std::chrono::nanoseconds & rate);
 
   /**
    * @brief Get the time when the action execution started.
@@ -101,9 +113,6 @@ protected:
    * @return std::stringThe action name.
    */
   const std::string get_action_name() const {return action_managed_;}
-
-  using CallbackReturnT =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
   /**
    * @brief Configures the node.

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -27,6 +27,7 @@ namespace plansys2
 {
 
 using namespace std::chrono_literals;
+using std::placeholders::_1;
 
 ActionExecutorClient::ActionExecutorClient(const std::string & node_name)
 : CascadeLifecycleNode(node_name),
@@ -44,9 +45,21 @@ ActionExecutorClient::ActionExecutorClient(const std::string & node_name)
   status_.node_name = get_name();
 }
 
-using CallbackReturnT =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-using std::placeholders::_1;
+ActionExecutorClient::ActionExecutorClient(
+  const std::string & node_name, const std::chrono::nanoseconds & rate)
+: CascadeLifecycleNode(node_name),
+  period_(rate), committed_(false)
+{
+  declare_parameter<std::string>("action_name", "");
+  declare_parameter<std::vector<std::string>>(
+    "specialized_arguments", std::vector<std::string>({}));
+
+  double default_rate = 1.0 / std::chrono::duration<double>(period_).count();
+  declare_parameter<double>("rate", default_rate);
+  status_.state = plansys2_msgs::msg::ActionPerformerStatus::NOT_READY;
+  status_.status_stamp = now();
+  status_.node_name = get_name();
+}
 
 CallbackReturnT
 ActionExecutorClient::on_configure(const rclcpp_lifecycle::State & state)

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -28,18 +28,16 @@ namespace plansys2
 
 using namespace std::chrono_literals;
 
-ActionExecutorClient::ActionExecutorClient(
-  const std::string & node_name,
-  const std::chrono::nanoseconds & rate)
+ActionExecutorClient::ActionExecutorClient(const std::string & node_name)
 : CascadeLifecycleNode(node_name),
-  rate_(rate),
-  commited_(false)
+  committed_(false)
 {
   declare_parameter<std::string>("action_name", "");
   declare_parameter<std::vector<std::string>>(
     "specialized_arguments", std::vector<std::string>({}));
 
-  double default_rate = 1.0 / std::chrono::duration<double>(rate_).count();
+  period_ = std::chrono::milliseconds(200);
+  double default_rate = 1.0 / std::chrono::duration<double>(period_).count();
   declare_parameter<double>("rate", default_rate);
   status_.state = plansys2_msgs::msg::ActionPerformerStatus::NOT_READY;
   status_.status_stamp = now();
@@ -77,7 +75,7 @@ ActionExecutorClient::on_configure(const rclcpp_lifecycle::State & state)
   double rate;
   get_parameter("rate", rate);
 
-  rate_ = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+  period_ = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
     std::chrono::duration<double>(1.0 / rate));
 
   action_hub_pub_ = create_publisher<plansys2_msgs::msg::ActionExecution>(
@@ -102,10 +100,7 @@ ActionExecutorClient::on_activate(const rclcpp_lifecycle::State & state)
   status_.state = plansys2_msgs::msg::ActionPerformerStatus::RUNNING;
   status_.status_stamp = now();
   start_time_ = now();
-  timer_ = create_wall_timer(
-    rate_, std::bind(&ActionExecutorClient::do_work, this));
-
-//  do_work();
+  timer_ = create_wall_timer(period_, std::bind(&ActionExecutorClient::do_work, this));
 
   return CallbackReturnT::SUCCESS;
 }
@@ -126,24 +121,24 @@ ActionExecutorClient::action_hub_callback(const plansys2_msgs::msg::ActionExecut
   switch (msg->type) {
     case plansys2_msgs::msg::ActionExecution::REQUEST:
       if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-        !commited_ && should_execute(msg->action, msg->arguments))
+        !committed_ && should_execute(msg->action, msg->arguments))
       {
-        commited_ = true;
+        committed_ = true;
         send_response(msg);
       }
       break;
     case plansys2_msgs::msg::ActionExecution::CONFIRM:
       if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-        commited_ && msg->node_id == get_name())
+        committed_ && msg->node_id == get_name())
       {
         current_arguments_ = msg->arguments;
         trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
-        commited_ = false;
+        committed_ = false;
       }
       break;
     case plansys2_msgs::msg::ActionExecution::REJECT:
       if (msg->node_id == get_name()) {
-        commited_ = false;
+        committed_ = false;
       }
       break;
     case plansys2_msgs::msg::ActionExecution::CANCEL:

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -360,7 +360,7 @@ ComputeBT::computeBTCallback(
   bool enable_groot_monitoring = get_parameter("enable_groot_monitoring").as_bool();
   int server_port = get_parameter("server_port").as_int();
   if (enable_groot_monitoring) {
-    RCLCPP_INFO(get_logger(), "Enabling Groot2 monitoring on port: %d", get_name(), server_port);
+    RCLCPP_INFO(get_logger(), "Enabling Groot2 monitoring on port: %i", server_port);
     addGrootMonitoring(&tree, server_port);
   }
 

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -66,14 +66,14 @@ class MoveAction : public plansys2::ActionExecutorClient
 {
 public:
   using Ptr = std::shared_ptr<MoveAction>;
-  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<MoveAction>(node_name, rate);
+    return std::make_shared<MoveAction>(node_name);
   }
 
 
-  MoveAction(const std::string & id, const std::chrono::nanoseconds & rate)
-  : ActionExecutorClient(id, rate)
+  MoveAction(const std::string & id)
+  : ActionExecutorClient(id)
   {
     executions_ = 0;
     cycles_ = 0;
@@ -114,7 +114,7 @@ TEST(action_execution, protocol_basic)
 {
   auto test_node = rclcpp::Node::make_shared("test_node");
   auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
-  auto move_action_node = std::make_shared<MoveAction>("move_action", 1s);
+  auto move_action_node = std::make_shared<MoveAction>("move_action");
   auto move_action_executor = plansys2::ActionExecutor::make_shared(
     "(move r2d2 steering_wheels_zone assembly_zone)", test_lf_node);
 
@@ -124,6 +124,7 @@ TEST(action_execution, protocol_basic)
   ASSERT_EQ(move_action_executor->get_action_params()[2], "assembly_zone");
 
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 1.0});
 
   rclcpp::experimental::executors::EventsExecutor exe;
 
@@ -229,7 +230,7 @@ TEST(action_execution, protocol_cancelation)
 {
   auto test_node = rclcpp::Node::make_shared("test_node");
   auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
-  auto move_action_node = std::make_shared<MoveAction>("move_action", 1s);
+  auto move_action_node = std::make_shared<MoveAction>("move_action");
   auto move_action_executor = plansys2::ActionExecutor::make_shared(
     "(move r2d2 steering_wheels_zone assembly_zone)", test_lf_node);
 
@@ -239,6 +240,7 @@ TEST(action_execution, protocol_cancelation)
   ASSERT_EQ(move_action_executor->get_action_params()[2], "assembly_zone");
 
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 1.0});
 
   rclcpp::experimental::executors::EventsExecutor exe;
 

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -72,7 +72,7 @@ public:
   }
 
 
-  MoveAction(const std::string & id)
+  explicit MoveAction(const std::string & id)
   : ActionExecutorClient(id)
   {
     executions_ = 0;

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -84,14 +84,14 @@ class MoveAction : public plansys2::ActionExecutorClient
 {
 public:
   using Ptr = std::shared_ptr<MoveAction>;
-  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<MoveAction>(node_name, rate);
+    return std::make_shared<MoveAction>(node_name);
   }
 
 
-  MoveAction(const std::string & id, const std::chrono::nanoseconds & rate)
-  : ActionExecutorClient(id, rate),
+  MoveAction(const std::string & id)
+  : ActionExecutorClient(id),
     executions_(0),
     cycles_(0),
     runtime_(0)
@@ -163,14 +163,14 @@ class TransportAction : public plansys2::ActionExecutorClient
 {
 public:
   using Ptr = std::shared_ptr<MoveAction>;
-  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<MoveAction>(node_name, rate);
+    return std::make_shared<MoveAction>(node_name);
   }
 
 
-  TransportAction(const std::string & id, const std::chrono::nanoseconds & rate)
-  : ActionExecutorClient(id, rate)
+  TransportAction(const std::string & id)
+  : ActionExecutorClient(id)
   {
     executions_ = 0;
     cycles_ = 0;
@@ -224,13 +224,16 @@ TEST(executor, action_executor_client)
   auto test_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
   auto aux_node = rclcpp_lifecycle::LifecycleNode::make_shared("aux_node");
 
-  auto move_action_1_node = MoveAction::make_shared("move_node_1", 100ms);
-  auto move_action_2_node = MoveAction::make_shared("move_node_2", 100ms);
-  auto transport_action_node = TransportAction::make_shared("transport_node", 50ms);
+  auto move_action_1_node = MoveAction::make_shared("move_node_1");
+  auto move_action_2_node = MoveAction::make_shared("move_node_2");
+  auto transport_action_node = TransportAction::make_shared("transport_node");
 
   move_action_1_node->set_parameter({"action_name", "move"});
+  move_action_1_node->set_parameter({"rate", 10.0});
   move_action_2_node->set_parameter({"action_name", "move"});
+  move_action_2_node->set_parameter({"rate", 10.0});
   transport_action_node->set_parameter({"action_name", "transport"});
+  transport_action_node->set_parameter({"rate", 20.0});
 
   move_action_1_node->set_parameter(
     {"specialized_arguments", std::vector<std::string>({"robot1"})});
@@ -677,8 +680,9 @@ TEST(executor, action_real_action_1)
   auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -932,8 +936,9 @@ TEST(executor, action_real_action_1_with_restore)
   auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -1206,8 +1211,9 @@ TEST(executor, action_real_action_2)
   auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -1465,8 +1471,9 @@ TEST(executor, cancel_bt_execution)
   auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -1666,8 +1673,9 @@ TEST(executor, executor_client_execute_plan)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -1815,7 +1823,8 @@ TEST(executor, executor_client_execute_plan_2)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
+  move_action_node->set_parameter({"rate", 10.0});
   move_action_node->set_parameter({"action_name", "move"});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
@@ -1961,7 +1970,8 @@ TEST(executor, executor_client_execute_plan_3)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
+  move_action_node->set_parameter({"rate", 10.0});
   move_action_node->set_parameter({"action_name", "move"});
   move_action_node->set_runtime(2.0);
 
@@ -2096,8 +2106,9 @@ TEST(executor, executor_client_execute_plan_two_plans)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
   move_action_node->set_runtime(2.0);
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
@@ -2265,8 +2276,9 @@ TEST(executor, executor_client_execute_plan_replan)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
   move_action_node->set_runtime(2.0);
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
@@ -2424,14 +2436,17 @@ TEST(executor, executor_client_execute_plan_multi_replan)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node_1 = MoveAction::make_shared("move_action_performer_1", 100ms);
+  auto move_action_node_1 = MoveAction::make_shared("move_action_performer_1");
   move_action_node_1->set_parameter({"action_name", "move"});
+  move_action_node_1->set_parameter({"rate", 10.0});
   move_action_node_1->set_runtime(2.0);
-  auto move_action_node_2 = MoveAction::make_shared("move_action_performer_2", 100ms);
+  auto move_action_node_2 = MoveAction::make_shared("move_action_performer_2");
   move_action_node_2->set_parameter({"action_name", "move"});
+  move_action_node_2->set_parameter({"rate", 10.0});
   move_action_node_2->set_runtime(2.0);
-  auto move_action_node_3 = MoveAction::make_shared("move_action_performer_3", 100ms);
+  auto move_action_node_3 = MoveAction::make_shared("move_action_performer_3");
   move_action_node_3->set_parameter({"action_name", "move"});
+  move_action_node_3->set_parameter({"rate", 10.0});
   move_action_node_3->set_runtime(2.0);
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
@@ -2598,14 +2613,14 @@ class PatrolAction : public plansys2::ActionExecutorClient
 {
 public:
   using Ptr = std::shared_ptr<PatrolAction>;
-  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<PatrolAction>(node_name, rate);
+    return std::make_shared<PatrolAction>(node_name);
   }
 
 
-  PatrolAction(const std::string & id, const std::chrono::nanoseconds & rate)
-  : ActionExecutorClient(id, rate)
+  PatrolAction(const std::string & id)
+  : ActionExecutorClient(id)
   {
     executions_ = 0;
     cycles_ = 0;
@@ -2654,11 +2669,13 @@ TEST(executor, executor_client_ordered_sub_goals)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
 
-  auto patrol_action_node = PatrolAction::make_shared("patrol_action_performer", 100ms);
+  auto patrol_action_node = PatrolAction::make_shared("patrol_action_performer");
   patrol_action_node->set_parameter({"action_name", "patrol"});
+  move_action_node->set_parameter({"rate", 10.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -2806,8 +2823,9 @@ TEST(executor, executor_client_cancel_plan)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 1s);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 1.0});
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();
   auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
@@ -2939,8 +2957,9 @@ TEST(executor, action_timeout)
   auto planner_node = std::make_shared<plansys2::PlannerNode>();
   auto executor_node = std::make_shared<ExecutorNodeTest>();
 
-  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  auto move_action_node = MoveAction::make_shared("move_action_performer");
   move_action_node->set_parameter({"action_name", "move"});
+  move_action_node->set_parameter({"rate", 10.0});
   move_action_node->set_runtime(10.0);
 
   auto domain_client = std::make_shared<plansys2::DomainExpertClient>();

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -89,9 +89,21 @@ public:
     return std::make_shared<MoveAction>(node_name);
   }
 
+  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  {
+    return std::make_shared<MoveAction>(node_name, rate);
+  }
 
   explicit MoveAction(const std::string & id)
   : ActionExecutorClient(id),
+    executions_(0),
+    cycles_(0),
+    runtime_(0)
+  {
+  }
+
+  MoveAction(const std::string & id, const std::chrono::nanoseconds & rate)
+  : ActionExecutorClient(id, rate),
     executions_(0),
     cycles_(0),
     runtime_(0)
@@ -162,15 +174,26 @@ public:
 class TransportAction : public plansys2::ActionExecutorClient
 {
 public:
-  using Ptr = std::shared_ptr<MoveAction>;
+  using Ptr = std::shared_ptr<TransportAction>;
   static Ptr make_shared(const std::string & node_name)
   {
-    return std::make_shared<MoveAction>(node_name);
+    return std::make_shared<TransportAction>(node_name);
   }
 
+  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  {
+    return std::make_shared<TransportAction>(node_name, rate);
+  }
 
   explicit TransportAction(const std::string & id)
   : ActionExecutorClient(id)
+  {
+    executions_ = 0;
+    cycles_ = 0;
+  }
+
+  TransportAction(const std::string & id, const std::chrono::nanoseconds & rate)
+  : ActionExecutorClient(id, rate)
   {
     executions_ = 0;
     cycles_ = 0;
@@ -234,6 +257,107 @@ TEST(executor, action_executor_client)
   move_action_2_node->set_parameter({"rate", 10.0});
   transport_action_node->set_parameter({"action_name", "transport"});
   transport_action_node->set_parameter({"rate", 20.0});
+
+  move_action_1_node->set_parameter(
+    {"specialized_arguments", std::vector<std::string>({"robot1"})});
+  move_action_2_node->set_parameter(
+    {"specialized_arguments", std::vector<std::string>({"robot2"})});
+
+  test_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  aux_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_2_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  transport_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  test_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  aux_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  rclcpp::experimental::executors::EventsExecutor exe;
+
+  exe.add_node(test_node->get_node_base_interface());
+  exe.add_node(aux_node->get_node_base_interface());
+  exe.add_node(move_action_1_node->get_node_base_interface());
+  exe.add_node(move_action_2_node->get_node_base_interface());
+  exe.add_node(transport_action_node->get_node_base_interface());
+
+  std::vector<plansys2_msgs::msg::ActionExecution> history_msgs;
+  bool confirmed = false;
+  auto actions_sub = aux_node->create_subscription<plansys2_msgs::msg::ActionExecution>(
+    "actions_hub",
+    rclcpp::QoS(100).reliable(), [&](plansys2_msgs::msg::ActionExecution::UniquePtr msg) {
+      history_msgs.push_back(*msg);
+    });
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+
+  std::string bt_xml_tree =
+    R"(
+    <root BTCPP_format="4" main_tree_to_execute = "MainTree" >
+      <BehaviorTree ID="MainTree">
+        <Sequence name="root_sequence">
+          <Parallel success_count="2" failure_count="1">
+            <ExecuteAction    action="(move robot1 wheels_zone assembly_zone):5"/>
+            <ExecuteAction    action="(move robot1 steering_wheels_zone assembly_zone):5"/>
+          </Parallel>
+          <ExecuteAction    action="(transport robot2 steering_wheels_zone assembly_zone):10"/>
+          <ExecuteAction    action="(move robot2 wheels_zone assembly_zone):15"/>
+          <ExecuteAction    action="(transport robot2 steering_wheels_zone assembly_zone):20"/>
+          <ExecuteAction    action="(move robot1 wheels_zone assembly_zone):25"/>
+          <ExecuteAction    action="(transport robot2 steering_wheels_zone assembly_zone):30"/>
+          <ExecuteAction    action="(move robot1 steering_wheels_zone assembly_zone):35"/>
+       </Sequence>
+      </BehaviorTree>
+    </root>
+  )";
+
+  auto blackboard = BT::Blackboard::create();
+
+  auto action_map = std::make_shared<std::map<std::string, plansys2::ActionExecutionInfo>>();
+  blackboard->set("action_map", action_map);
+  blackboard->set("node", test_node);
+
+  BT::BehaviorTreeFactory factory;
+  factory.registerNodeType<plansys2::ExecuteAction>("ExecuteAction");
+  factory.registerNodeType<plansys2::WaitAction>("WaitAction");
+
+  auto tree = factory.createTreeFromText(bt_xml_tree, blackboard);
+
+
+  auto status = BT::NodeStatus::RUNNING;
+  while (status != BT::NodeStatus::SUCCESS) {
+    status = tree.tickOnce();
+  }
+
+  ASSERT_EQ(status, BT::NodeStatus::SUCCESS);
+  ASSERT_EQ(move_action_1_node->executions_, 4);
+  ASSERT_EQ(move_action_1_node->cycles_, 20);
+  ASSERT_EQ(move_action_2_node->executions_, 1);
+  ASSERT_EQ(move_action_2_node->cycles_, 5);
+  ASSERT_EQ(transport_action_node->executions_, 3);
+  ASSERT_EQ(transport_action_node->cycles_, 15);
+  // ASSERT_EQ(history_msgs.size(), 64);
+
+
+  finish = true;
+  t.join();
+}
+
+TEST(executor, action_executor_client_old_constructor)
+{
+  auto test_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto aux_node = rclcpp_lifecycle::LifecycleNode::make_shared("aux_node");
+
+  auto move_action_1_node = MoveAction::make_shared("move_node_1", 100ms);
+  auto move_action_2_node = MoveAction::make_shared("move_node_2", 100ms);
+  auto transport_action_node = TransportAction::make_shared("transport_node", 50ms);
+
+  move_action_1_node->set_parameter({"action_name", "move"});
+  move_action_2_node->set_parameter({"action_name", "move"});
+  transport_action_node->set_parameter({"action_name", "transport"});
 
   move_action_1_node->set_parameter(
     {"specialized_arguments", std::vector<std::string>({"robot1"})});

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -90,7 +90,7 @@ public:
   }
 
 
-  MoveAction(const std::string & id)
+  explicit MoveAction(const std::string & id)
   : ActionExecutorClient(id),
     executions_(0),
     cycles_(0),
@@ -169,7 +169,7 @@ public:
   }
 
 
-  TransportAction(const std::string & id)
+  explicit TransportAction(const std::string & id)
   : ActionExecutorClient(id)
   {
     executions_ = 0;
@@ -2619,7 +2619,7 @@ public:
   }
 
 
-  PatrolAction(const std::string & id)
+  explicit PatrolAction(const std::string & id)
   : ActionExecutorClient(id)
   {
     executions_ = 0;

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -42,13 +42,13 @@ class ActT : public plansys2::ActionExecutorClient
 {
 public:
   ActT()
-  : plansys2::ActionExecutorClient("None", 1s)
+  : plansys2::ActionExecutorClient("None")
   {
     progress_ = 0.0;
     name_ = std::string("None");
   }
   explicit ActT(const std::string name)
-  : plansys2::ActionExecutorClient(name, 1s)
+  : plansys2::ActionExecutorClient(name)
   {
     progress_ = 0.0;
     name_ = name;
@@ -816,15 +816,19 @@ TEST_F(TerminalTestCase, check_actors)
 
   using namespace std::chrono_literals;
 
-  auto move_actor_1_node = plansys2::ActionExecutorClient::make_shared("move_1", 100ms);
-  auto move_actor_2_node = plansys2::ActionExecutorClient::make_shared("move_2", 100ms);
-  auto ask_charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("askcharge", 100ms);
-  auto charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("charge", 100ms);
+  auto move_actor_1_node = plansys2::ActionExecutorClient::make_shared("move_1");
+  auto move_actor_2_node = plansys2::ActionExecutorClient::make_shared("move_2");
+  auto ask_charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("askcharge");
+  auto charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("charge");
 
   move_actor_1_node->set_parameter({"action_name", "move"});
+  move_actor_1_node->set_parameter({"rate", 10.0});
   move_actor_2_node->set_parameter({"action_name", "move"});
+  move_actor_2_node->set_parameter({"rate", 10.0});
   ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
+  ask_charge_actor_1_node->set_parameter({"rate", 10.0});
   charge_actor_1_node->set_parameter({"action_name", "charge"});
+  charge_actor_1_node->set_parameter({"rate", 10.0});
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
 
@@ -968,8 +972,11 @@ TEST_F(TerminalTestCase, source_run_plan)
   auto charge_actor_1_node = std::make_shared<ActT>("charge");
 
   move_actor_1_node->set_parameter({"action_name", "move"});
+  move_actor_1_node->set_parameter({"rate", 1.0});
   ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
+  ask_charge_actor_1_node->set_parameter({"rate", 1.0});
   charge_actor_1_node->set_parameter({"action_name", "charge"});
+  charge_actor_1_node->set_parameter({"rate", 1.0});
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
 

--- a/plansys2_tests/include/plansys2_tests/test_action_node.hpp
+++ b/plansys2_tests/include/plansys2_tests/test_action_node.hpp
@@ -33,19 +33,16 @@ class TestAction : public plansys2::ActionExecutorClient
 public:
   using Ptr = std::shared_ptr<TestAction>;
   static Ptr make_shared(
-    const std::string & action,
-    const std::chrono::seconds & rate = 1s, float increment = 0.4)
+    const std::string & action, float increment = 0.4)
   {
-    auto ret = std::make_shared<TestAction>(action, rate, increment);
+    auto ret = std::make_shared<TestAction>(action, increment);
     ret->set_parameter(rclcpp::Parameter("action_name", action));
+    ret->set_parameter(rclcpp::Parameter("rate", 1.0));
     ret->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
     return ret;
   }
 
-  TestAction(
-    const std::string & action_name,
-    const std::chrono::seconds & rate = 1s,
-    float increment = 0.4);
+  TestAction(const std::string & action_name, float increment = 0.4);
 
 private:
   void do_work();

--- a/plansys2_tests/include/plansys2_tests/test_action_node.hpp
+++ b/plansys2_tests/include/plansys2_tests/test_action_node.hpp
@@ -42,7 +42,7 @@ public:
     return ret;
   }
 
-  TestAction(const std::string & action_name, float increment = 0.4);
+  explicit TestAction(const std::string & action_name, float increment = 0.4);
 
 private:
   void do_work();

--- a/plansys2_tests/src/plansys2_tests/test_action_node.cpp
+++ b/plansys2_tests/src/plansys2_tests/test_action_node.cpp
@@ -26,10 +26,9 @@ namespace plansys2_tests
 
 int TestAction::node_name_counter_ = 0;
 
-TestAction::TestAction(
-  const std::string & action_name, const std::chrono::seconds & rate, float increment)
-: plansys2::ActionExecutorClient(action_name + std::to_string(node_name_counter_++),
-    rate), increment_(increment)
+TestAction::TestAction(const std::string & action_name, float increment)
+: plansys2::ActionExecutorClient(action_name + std::to_string(node_name_counter_++)),
+  increment_(increment)
 {
   progress_ = 0.0;
 }


### PR DESCRIPTION
I made some improvements to the BTActions:
- I added ```server_timeout``` as a parameter.
- I split timeouts between server and wait, and I added a new ```wait_for_service_timeout``` parameter.
- I removed the rate from the ActionExecutorClient constructor to simplify its usage, it was only used in bt_actions, and is now a fully set parameter. I renamed the internal member to 'period_' for clarification. The default is 200ms / 5.0Hz.
- I added a new utils to function (from Davide in Nav2) to handle with the setting-getting of the ports / blackboard.
- The new parameters are set in the blackboard of the BT. Adding to the blackboard it makes all Nav2 nodes compatible with PlanSys2.

