### PR TITLE
Add tf2_geometry_msgs to plansys2_bt_actions package.xml

### DIFF
--- a/plansys2_bt_actions/package.xml
+++ b/plansys2_bt_actions/package.xml
@@ -26,6 +26,7 @@
   <test_depend>plansys2_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Add tf2_geometry_msgs to plansys2_bt_actions package.xml. tf2_geometry_msgs is required to build plansys2_bt_actions