### PR TITLE
Plansys2 domain expert

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -20,6 +20,8 @@
 #include <vector>
 #include <memory>
 
+#include "plansys2_core/State.hpp"
+
 #include "plansys2_msgs/msg/action.hpp"
 #include "plansys2_msgs/msg/derived.hpp"
 #include "plansys2_msgs/msg/durative_action.hpp"
@@ -112,13 +114,19 @@ public:
    */
   std::optional<plansys2::Function> getFunction(const std::string & function);
 
+  plansys2_msgs::msg::Derived getDerivedFromDomain(
+    unsigned int i, const std::vector<std::string> & params = {});
+
+  /// Get the derived predicates existing in the domain.
   /**
    * @brief Get the derived predicates defined in the domain.
    *
    * @return std::vector<plansys2::Predicate> Vector containing the derived predicates
    *         defined in the domain.
    */
-  std::vector<plansys2::Predicate> getDerivedPredicates();
+  std::vector<plansys2_msgs::msg::Derived> getDerivedPredicates();
+
+  plansys2::DerivedResolutionGraph getDerivedResolutionGraph();
 
   /**
    * @brief Get the details of a derived predicate defined in the domain.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -123,7 +123,7 @@ public:
    *
    */
   plansys2_msgs::msg::Derived getDerivedFromDomain(
-    const unsigned int&  derived_index, const std::vector<std::string> & params = {});
+    const unsigned int & derived_index, const std::vector<std::string> & params = {});
 
   /// Get the derived predicates existing in the domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <memory>
 
-#include "plansys2_core/State.hpp"
+#include "plansys2_core/DerivedResolutionGraph.hpp"
 
 #include "plansys2_msgs/msg/action.hpp"
 #include "plansys2_msgs/msg/derived.hpp"

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -114,8 +114,16 @@ public:
    */
   std::optional<plansys2::Function> getFunction(const std::string & function);
 
+  /**
+   * @brief Get a derived predicate from the domain given an index and parameters.
+   *
+   * @param derived_index The index of the derived predicate in the domain.
+   * @param params The parameters for the derived predicate (empty by default).
+   * @return plansys2_msgs::msg::Derived The derived predicate message.
+   *
+   */
   plansys2_msgs::msg::Derived getDerivedFromDomain(
-    unsigned int i, const std::vector<std::string> & params = {});
+    const unsigned int&  derived_index, const std::vector<std::string> & params = {});
 
   /// Get the derived predicates existing in the domain.
   /**

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "plansys2_core/Types.hpp"
+#include "plansys2_core/DerivedResolutionGraph.hpp"
 #include "plansys2_domain_expert/DomainExpertInterface.hpp"
 
 #include "std_msgs/msg/string.hpp"
@@ -122,7 +123,9 @@ public:
    * @return std::vector<plansys2::Predicate> Vector containing the derived predicates
    *         defined in the domain.
    */
-  std::vector<plansys2::Predicate> getDerivedPredicates();
+  std::vector<plansys2_msgs::msg::Derived> getDerivedPredicates();
+
+  plansys2::DerivedResolutionGraph getDerivedResolutionGraph();
 
   /**
    * @brief Get the details of a derived predicate defined in the domain.
@@ -206,7 +209,8 @@ private:
   rclcpp::Client<plansys2_msgs::srv::GetDomainConstants>::SharedPtr get_constants_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_predicates_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_functions_client_;
-  rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_derived_predicates_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>::SharedPtr
+    get_derived_predicates_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>::SharedPtr
     get_derived_predicate_details_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainActions>::SharedPtr get_actions_client_;

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -104,7 +104,7 @@ public:
    * @return std::vector<plansys2::Predicate> Vector containing the derived predicates
    *         defined in the domain.
    */
-  virtual std::vector<plansys2::Predicate> getDerivedPredicates() = 0;
+  virtual std::vector<plansys2_msgs::msg::Derived> getDerivedPredicates() = 0;
 
   /**
    * @brief Get the details of a derived predicate defined in the domain.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -234,8 +234,8 @@ public:
    */
   void get_domain_derived_predicates_service_callback(
     const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<plansys2_msgs::srv::GetStates::Request> request,
-    const std::shared_ptr<plansys2_msgs::srv::GetStates::Response> response);
+    const std::shared_ptr<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Response> response);
 
   /**
    * @brief Service callback to retrieve details of a specific derived predicate.
@@ -281,7 +281,7 @@ private:
     get_domain_functions_service_;
   rclcpp::Service<plansys2_msgs::srv::GetNodeDetails>::SharedPtr
     get_domain_function_details_service_;
-  rclcpp::Service<plansys2_msgs::srv::GetStates>::SharedPtr
+  rclcpp::Service<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>::SharedPtr
     get_domain_derived_predicates_service_;
   rclcpp::Service<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>::SharedPtr
     get_domain_derived_predicate_details_service_;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -167,7 +167,7 @@ DomainExpert::getFunction(const std::string & function)
 }
 
 plansys2_msgs::msg::Derived DomainExpert::getDerivedFromDomain(
-  const unsigned int& derived_index, const std::vector<std::string> & params)
+  const unsigned int & derived_index, const std::vector<std::string> & params)
 {
   plansys2_msgs::msg::Derived derived;
   derived.predicate.name = domain_->derived[derived_index]->name;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -166,27 +166,26 @@ DomainExpert::getFunction(const std::string & function)
   }
 }
 
-
 plansys2_msgs::msg::Derived DomainExpert::getDerivedFromDomain(
-  unsigned int i, const std::vector<std::string> & params)
+  const unsigned int& derived_index, const std::vector<std::string> & params)
 {
   plansys2_msgs::msg::Derived derived;
-  derived.predicate.name = domain_->derived[i]->name;
+  derived.predicate.name = domain_->derived[derived_index]->name;
   derived.predicate.node_type = plansys2_msgs::msg::Node::PREDICATE;
 
   // Parameters
-  for (unsigned j = 0; j < domain_->derived[i]->params.size(); j++) {
+  for (unsigned j = 0; j < domain_->derived[derived_index]->params.size(); j++) {
     plansys2_msgs::msg::Param param;
-    param.name = "?" + domain_->types[domain_->derived[i]->params[j]]->getName() +
+    param.name = "?" + domain_->types[domain_->derived[derived_index]->params[j]]->getName() +
       std::to_string(j);
-    param.type = domain_->types[domain_->derived[i]->params[j]]->name;
-    domain_->types[domain_->derived[i]->params[j]]->getSubTypesNames(param.sub_types);
+    param.type = domain_->types[domain_->derived[derived_index]->params[j]]->name;
+    domain_->types[domain_->derived[derived_index]->params[j]]->getSubTypesNames(param.sub_types);
     derived.predicate.parameters.push_back(param);
   }
 
   // Preconditions
-  if (domain_->derived[i]->cond) {
-    domain_->derived[i]->cond->getTree(derived.preconditions, *domain_, params);
+  if (domain_->derived[derived_index]->cond) {
+    domain_->derived[derived_index]->cond->getTree(derived.preconditions, *domain_, params);
   }
 
   return derived;

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -166,17 +166,46 @@ DomainExpert::getFunction(const std::string & function)
   }
 }
 
-std::vector<plansys2::Predicate>
+
+plansys2_msgs::msg::Derived DomainExpert::getDerivedFromDomain(
+  unsigned int i, const std::vector<std::string> & params)
+{
+  plansys2_msgs::msg::Derived derived;
+  derived.predicate.name = domain_->derived[i]->name;
+  derived.predicate.node_type = plansys2_msgs::msg::Node::PREDICATE;
+
+  // Parameters
+  for (unsigned j = 0; j < domain_->derived[i]->params.size(); j++) {
+    plansys2_msgs::msg::Param param;
+    param.name = "?" + domain_->types[domain_->derived[i]->params[j]]->getName() +
+      std::to_string(j);
+    param.type = domain_->types[domain_->derived[i]->params[j]]->name;
+    domain_->types[domain_->derived[i]->params[j]]->getSubTypesNames(param.sub_types);
+    derived.predicate.parameters.push_back(param);
+  }
+
+  // Preconditions
+  if (domain_->derived[i]->cond) {
+    domain_->derived[i]->cond->getTree(derived.preconditions, *domain_, params);
+  }
+
+  return derived;
+}
+
+std::vector<plansys2_msgs::msg::Derived>
 DomainExpert::getDerivedPredicates()
 {
-  std::vector<plansys2::Predicate> ret;
+  std::vector<plansys2_msgs::msg::Derived> ret;
   for (unsigned i = 0; i < domain_->derived.size(); i++) {
-    plansys2_msgs::msg::Node pred;
-    pred.node_type = plansys2_msgs::msg::Node::PREDICATE;
-    pred.name = domain_->derived[i]->name;
-    ret.push_back(pred);
+    ret.push_back(getDerivedFromDomain(i));
   }
   return ret;
+}
+
+plansys2::DerivedResolutionGraph
+DomainExpert::getDerivedResolutionGraph()
+{
+  return plansys2::DerivedResolutionGraph(getDerivedPredicates());
 }
 
 std::vector<plansys2_msgs::msg::Derived>
@@ -194,25 +223,7 @@ DomainExpert::getDerivedPredicate(
 
   while (i < domain_->derived.size()) {
     if (domain_->derived[i]->name == predicate_search) {
-      plansys2_msgs::msg::Derived derived;
-      derived.predicate.name = predicate_search;
-
-      // Parameters
-      for (unsigned j = 0; j < domain_->derived[i]->params.size(); j++) {
-        plansys2_msgs::msg::Param param;
-        param.name = "?" + domain_->types[domain_->derived[i]->params[j]]->getName() +
-          std::to_string(j);
-        param.type = domain_->types[domain_->derived[i]->params[j]]->name;
-        domain_->types[domain_->derived[i]->params[j]]->getSubTypesNames(param.sub_types);
-        derived.predicate.parameters.push_back(param);
-      }
-
-      // Preconditions
-      if (domain_->derived[i]->cond) {
-        domain_->derived[i]->cond->getTree(derived.preconditions, *domain_, params);
-      }
-
-      ret.push_back(derived);
+      ret.push_back(getDerivedFromDomain(i, params));
     }
     i++;
   }

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -40,7 +40,8 @@ DomainExpertClient::DomainExpertClient()
     "domain_expert/get_domain_predicates");
   get_functions_client_ = node_->create_client<plansys2_msgs::srv::GetStates>(
     "domain_expert/get_domain_functions");
-  get_derived_predicates_client_ = node_->create_client<plansys2_msgs::srv::GetStates>(
+  get_derived_predicates_client_ =
+    node_->create_client<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>(
     "domain_expert/get_domain_derived_predicates");
   get_derived_predicate_details_client_ =
     node_->create_client<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>(
@@ -308,10 +309,10 @@ DomainExpertClient::getFunction(const std::string & function)
   return {};
 }
 
-std::vector<plansys2::Predicate>
+std::vector<plansys2_msgs::msg::Derived>
 DomainExpertClient::getDerivedPredicates()
 {
-  std::vector<plansys2::Predicate> ret;
+  std::vector<plansys2_msgs::msg::Derived> ret;
 
   while (!get_derived_predicates_client_->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
@@ -323,7 +324,7 @@ DomainExpertClient::getDerivedPredicates()
         " service client: waiting for service to appear...");
   }
 
-  auto request = std::make_shared<plansys2_msgs::srv::GetStates::Request>();
+  auto request = std::make_shared<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Request>();
 
   auto future_result = get_derived_predicates_client_->async_send_request(request);
 
@@ -333,12 +334,35 @@ DomainExpertClient::getDerivedPredicates()
     return ret;
   }
 
-  auto result = *future_result.get();
+  return future_result.get()->predicates;
+}
 
-  ret = plansys2::convertVector<plansys2::Predicate, plansys2_msgs::msg::Node>(
-    result.states);
+plansys2::DerivedResolutionGraph
+DomainExpertClient::getDerivedResolutionGraph()
+{
+  plansys2::DerivedResolutionGraph ret;
 
-  return ret;
+  while (!get_derived_predicates_client_->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      return ret;
+    }
+    RCLCPP_ERROR_STREAM(
+      node_->get_logger(),
+      get_derived_predicates_client_->get_service_name() <<
+        " service client: waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Request>();
+
+  auto future_result = get_derived_predicates_client_->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node_, future_result, std::chrono::seconds(1)) !=
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
+    return ret;
+  }
+
+  return plansys2::DerivedResolutionGraph(future_result.get()->predicates);
 }
 
 std::vector<plansys2_msgs::msg::Derived>

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -89,7 +89,8 @@ DomainExpertNode::DomainExpertNode()
       &DomainExpertNode::get_domain_function_details_service_callback,
       this, std::placeholders::_1, std::placeholders::_2,
       std::placeholders::_3));
-  get_domain_derived_predicates_service_ = create_service<plansys2_msgs::srv::GetStates>(
+  get_domain_derived_predicates_service_ =
+    create_service<plansys2_msgs::srv::GetDomainDerivedPredicateDetails>(
     "domain_expert/get_domain_derived_predicates", std::bind(
       &DomainExpertNode::get_domain_derived_predicates_service_callback,
       this, std::placeholders::_1, std::placeholders::_2,
@@ -155,7 +156,7 @@ DomainExpertNode::on_configure(const rclcpp_lifecycle::State & state)
       auto request = std::make_shared<plansys2_msgs::srv::ValidateDomain::Request>();
       request->domain = domain_expert_->getDomain();
       auto future_result = validate_domain_client_->async_send_request(std::move(request));
-      if (future_result.wait_for(std::chrono::seconds(1)) != std::future_status::ready) {
+      if (future_result.wait_for(std::chrono::seconds(3)) != std::future_status::ready) {
         RCLCPP_ERROR(
           get_logger(), "Timed out waiting for service: %s",
           validate_domain_client_->get_service_name());
@@ -437,8 +438,8 @@ DomainExpertNode::get_domain_function_details_service_callback(
 void
 DomainExpertNode::get_domain_derived_predicates_service_callback(
   const std::shared_ptr<rmw_request_id_t> request_header,
-  const std::shared_ptr<plansys2_msgs::srv::GetStates::Request> request,
-  const std::shared_ptr<plansys2_msgs::srv::GetStates::Response> response)
+  const std::shared_ptr<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Request> request,
+  const std::shared_ptr<plansys2_msgs::srv::GetDomainDerivedPredicateDetails::Response> response)
 {
   if (domain_expert_ == nullptr) {
     response->success = false;
@@ -446,8 +447,7 @@ DomainExpertNode::get_domain_derived_predicates_service_callback(
     RCLCPP_WARN(get_logger(), "Requesting service in non-active state");
   } else {
     response->success = true;
-    response->states = plansys2::convertVector<plansys2_msgs::msg::Node, plansys2::Predicate>(
-      domain_expert_->getDerivedPredicates());
+    response->predicates = domain_expert_->getDerivedPredicates();
   }
 }
 

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -283,12 +283,12 @@ TEST(domain_expert, get_derived_predicates)
 
   plansys2::DomainExpert domain_expert(domain_str);
 
-  std::vector<plansys2::Predicate> predicates = domain_expert.getDerivedPredicates();
+  std::vector<plansys2_msgs::msg::Derived> predicates = domain_expert.getDerivedPredicates();
   std::vector<std::string> predicates_types {"inferred-robot_at", "inferred-person_at"};
 
   ASSERT_EQ(predicates.size(), predicates_types.size());
   for (unsigned i = 0; i < predicates.size(); i++) {
-    ASSERT_EQ(predicates[i].name, predicates_types[i]);
+    ASSERT_EQ(predicates[i].predicate.name, predicates_types[i]);
   }
 }
 

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 
+#include "plansys2_core/Action.hpp"
 #include "plansys2_executor/ActionExecutor.hpp"
 #include "plansys2_msgs/msg/plan.hpp"
 #include "plansys2_pddl_parser/Utils.hpp"

--- a/plansys2_executor/test/unit/simple_btbuilder_tests.cpp
+++ b/plansys2_executor/test/unit/simple_btbuilder_tests.cpp
@@ -281,18 +281,18 @@ TEST(simple_btbuilder_tests, test_plan_1)
   ASSERT_FALSE(btbuilder->is_action_executable(action_sequence[4], predicates, functions));
   ASSERT_FALSE(btbuilder->is_action_executable(action_sequence[5], predicates, functions));
 
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at leia entrance)"), true)), predicates.end());
-  ASSERT_EQ(
+        parser::pddl::fromStringPredicate("(robot_at leia entrance)"), true)) != predicates.end());
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at leia chargingroom)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at leia chargingroom)"), true)) ==
         predicates.end());
 
   plansys2::apply(
@@ -302,19 +302,19 @@ TEST(simple_btbuilder_tests, test_plan_1)
     action_sequence[0].action.get_at_end_effects(),
     predicates, functions);
 
-  ASSERT_EQ(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at leia entrance)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at leia entrance)"), true)) ==
         predicates.end());
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at leia chargingroom)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at leia chargingroom)"), true)) !=
         predicates.end());
 
   ASSERT_TRUE(btbuilder->is_action_executable(action_sequence[1], predicates, functions));
@@ -367,12 +367,12 @@ TEST(simple_btbuilder_tests, test_plan_1)
     action_sequence[5].action.get_at_end_effects(),
     predicates, functions);
 
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at leia bathroom)"), true)), predicates.end());
+        parser::pddl::fromStringPredicate("(robot_at leia bathroom)"), true)) != predicates.end());
 
   finish = true;
   t.join();
@@ -540,26 +540,26 @@ TEST(simple_btbuilder_tests, test_plan_2)
       predicates, functions);
   }
 
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at robot1 body_car_zone)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at robot1 body_car_zone)"), true)) !=
         predicates.end());
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at robot2 steering_wheels_zone)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at robot2 steering_wheels_zone)"), true)) !=
         predicates.end());
-  ASSERT_NE(
+  EXPECT_TRUE(
     std::find_if(
       predicates.begin(), predicates.end(),
       std::bind(
         &parser::pddl::checkNodeEquality, std::placeholders::_1,
-        parser::pddl::fromStringPredicate("(robot_at robot3 wheels_zone)"), true)),
+        parser::pddl::fromStringPredicate("(robot_at robot3 wheels_zone)"), true)) !=
         predicates.end());
 
   tree.nodes.clear();
@@ -567,7 +567,7 @@ TEST(simple_btbuilder_tests, test_plan_2)
     tree, "(robot_at robot1 body_car_zone)", false,
     plansys2_msgs::msg::Node::AND);
   auto node_satisfy_1 = btbuilder->get_node_satisfy(tree, *roots.begin(), nullptr);
-  ASSERT_NE(node_satisfy_1, nullptr);
+  EXPECT_TRUE(node_satisfy_1 != nullptr);
   ASSERT_EQ(node_satisfy_1->action.action.get_action_name(), "move");
   ASSERT_EQ(node_satisfy_1->action.action.get_action_params().size(), 3u);
   ASSERT_EQ(node_satisfy_1->action.action.get_action_params()[0].name, "robot1");
@@ -576,12 +576,12 @@ TEST(simple_btbuilder_tests, test_plan_2)
 
   auto it = roots.begin();
   it++;
-  ASSERT_EQ(btbuilder->get_node_satisfy(tree, *it, nullptr), nullptr);
+  EXPECT_TRUE(btbuilder->get_node_satisfy(tree, *it, nullptr) == nullptr);
   it++;
-  ASSERT_EQ(btbuilder->get_node_satisfy(tree, *it, nullptr), nullptr);
+  EXPECT_TRUE(btbuilder->get_node_satisfy(tree, *it, nullptr) == nullptr);
 
   auto graph = btbuilder->get_graph(plan.value());
-  ASSERT_NE(graph, nullptr);
+  EXPECT_TRUE(graph != nullptr);
 
   btbuilder->print_graph(graph);
 

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -125,7 +125,7 @@ ProblemExpert::getPredicates()
 
   auto derived_predicates = domain_expert_->getDerivedPredicates();
   for (auto derived_name : derived_predicates) {
-    auto derived = domain_expert_->getDerivedPredicate(derived_name.name);
+    auto derived = domain_expert_->getDerivedPredicate(derived_name.predicate.name);
     for (auto d : derived) {
       std::vector<std::vector<std::string>> parameters_vector;
       for (size_t i = 0; i < d.predicate.parameters.size(); i++) {

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -447,7 +447,7 @@ Terminal::process_get_model(std::vector<std::string> & command, std::ostringstre
 
       os << "Derived predicates: " << predicates.size() << std::endl;
       for (const auto & predicate : predicates) {
-        os << "\t" << predicate.name << std::endl;
+        os << "\t" << predicate.predicate.name << std::endl;
       }
     } else if (command[0] == "functions") {
       auto functions = domain_client_->getFunctions();


### PR DESCRIPTION
Related to PR https://github.com/PlanSys2/ros2_planning_system/pull/330. Continuation of PR #372.

Changes:
- return `std::vector<plansys2_msgs::msg::Derived>` instead of `std::vector<plansys2::Predicate>` in `getDerivedPredicates()`
- minor changes to [simple_btbuilder_tests.cpp](https://github.com/PlanSys2/ros2_planning_system/compare/rolling...Rezenders:ros2_planning_system:plansys2_domain_expert?expand=1#diff-f53c6780d7901bc5ed9217f6b657eed10ab533890dc1db13ceeee28d08cbe44a) to make tests pass

Adds:
- `plansys2::DerivedResolutionGraph getDerivedResolutionGraph()`

Next PR will be a big one with all the changes to the problem expert and the evaluate and apply functions