### PR TITLE
Allow `rolling` to build against ROS Jazzy

### DIFF
--- a/plansys2_core/test/utils_test.cpp
+++ b/plansys2_core/test/utils_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/plansys2_tools/include/rqt_plansys2_knowledge/RQTKnowledge.hpp
+++ b/plansys2_tools/include/rqt_plansys2_knowledge/RQTKnowledge.hpp
@@ -29,7 +29,12 @@
 #include <map>
 #include <memory>
 
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "rqt_gui_cpp/plugin.hpp"
+#else
+#include "rqt_gui_cpp/plugin.h"
+#endif
 
 #include "rqt_plansys2_knowledge/KnowledgeTree.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"

--- a/plansys2_tools/include/rqt_plansys2_performers/RQTPerformers.hpp
+++ b/plansys2_tools/include/rqt_plansys2_performers/RQTPerformers.hpp
@@ -30,7 +30,12 @@
 #include <memory>
 #include <string>
 
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "rqt_gui_cpp/plugin.hpp"
+#else
+#include "rqt_gui_cpp/plugin.h"
+#endif
 
 #include "rqt_plansys2_performers/PerformersTree.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"

--- a/plansys2_tools/include/rqt_plansys2_plan/RQTPlan.hpp
+++ b/plansys2_tools/include/rqt_plansys2_plan/RQTPlan.hpp
@@ -30,7 +30,12 @@
 #include <memory>
 #include <string>
 
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "rqt_gui_cpp/plugin.hpp"
+#else
+#include "rqt_gui_cpp/plugin.h"
+#endif
 
 #include "rqt_plansys2_plan/PlanTree.hpp"
 


### PR DESCRIPTION
As per title, and as discussed in #384.

This lets me follow the regular build & installation instructions and build `rolling` against a Jazzy install.

Note: I've only build-tested this. I've not actually run anything.
