### PR TITLE
Update CI to use container workers

### DIFF
--- a/.github/workflows/foxy-devel.yaml
+++ b/.github/workflows/foxy-devel.yaml
@@ -7,27 +7,25 @@ on:
   push:
     branches:
       - foxy-devel
-      
+  workflow_dispatch:
+
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-      fail-fast: false
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:focal
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - name: Fix pip
         run: pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.2.1
-        with:
-          required-ros-distributions: foxy
+        uses: ros-tooling/setup-ros@0.7.15
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.2.1
+        uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests
+          ref: foxy-devel
           target-ros2-distro: foxy
           colcon-defaults: |
             {
@@ -39,7 +37,7 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.1.0
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/foxy-devel.yaml
+++ b/.github/workflows/foxy-devel.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ubuntu:focal
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - name: Fix pip
         run: pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions
       - name: Setup ROS 2

--- a/.github/workflows/galactic-devel.yaml
+++ b/.github/workflows/galactic-devel.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ubuntu:focal
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - name: Fix pip
         run: python3 -m pip3 install pip3 --upgrade; pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions; pip3 install pyopenssl --upgrade
       - name: Setup ROS 2

--- a/.github/workflows/galactic-devel.yaml
+++ b/.github/workflows/galactic-devel.yaml
@@ -7,27 +7,25 @@ on:
   push:
     branches:
       - galactic-devel
-      
+  workflow_dispatch:
+
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-      fail-fast: false
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:focal
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - name: Fix pip
         run: python3 -m pip3 install pip3 --upgrade; pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions; pip3 install pyopenssl --upgrade
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.2.1
-        with:
-          required-ros-distributions: galactic
+        uses: ros-tooling/setup-ros@0.7.15
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.2.1
+        uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
+          ref: galactic-devel
           target-ros2-distro: galactic
           colcon-defaults: |
             {
@@ -39,7 +37,7 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.1.0
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/humble-devel.yaml
+++ b/.github/workflows/humble-devel.yaml
@@ -7,27 +7,25 @@ on:
   push:
     branches:
       - humble-devel
-      
+  workflow_dispatch:
+
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - name: Fix pip
         run: pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.3.3
-        with:
-          required-ros-distributions: humble
+        uses: ros-tooling/setup-ros@0.7.15
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.2.5
+        uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
+          ref: humble-devel
           target-ros2-distro: humble
           colcon-defaults: |
             {
@@ -38,7 +36,7 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/humble-devel.yaml
+++ b/.github/workflows/humble-devel.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ubuntu:jammy
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - name: Fix pip
         run: pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions
       - name: Setup ROS 2

--- a/.github/workflows/iron-devel.yaml
+++ b/.github/workflows/iron-devel.yaml
@@ -7,27 +7,25 @@ on:
   push:
     branches:
       - iron-devel
+  workflow_dispatch:
       
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - name: Fix pip
         run: python3 -m pip3 install pip3 --upgrade; pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions; pip3 install pyopenssl --upgrade
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.0
-        with:
-          required-ros-distributions: iron
+        uses: ros-tooling/setup-ros@0.7.15
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.3
+        uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
+          ref: iron-devel
           target-ros2-distro: iron
           colcon-defaults: |
             {
@@ -38,7 +36,7 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/iron-devel.yaml
+++ b/.github/workflows/iron-devel.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ubuntu:jammy
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - name: Fix pip
         run: python3 -m pip3 install pip3 --upgrade; pip3 install empy==3.3.4; pip3 install -U colcon-common-extensions; pip3 install pyopenssl --upgrade
       - name: Setup ROS 2

--- a/.github/workflows/jazzy-devel.yaml
+++ b/.github/workflows/jazzy-devel.yaml
@@ -9,13 +9,12 @@ on:
       - jazzy-devel
   schedule:
       - cron: '0 0 * * 6'     
+  workflow_dispatch:
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
@@ -24,10 +23,6 @@ jobs:
           ref: jazzy-devel
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: jazzy
-      - name: Install BT.CPP v4 and test_msgs (provisional Fix)
-        run: sudo apt-get install ros-jazzy-behaviortree-cpp ros-jazzy-test-msgs
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
@@ -44,7 +39,7 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/jazzy-devel.yaml
+++ b/.github/workflows/jazzy-devel.yaml
@@ -17,7 +17,7 @@ jobs:
       image: ubuntu:noble
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - uses: actions/checkout@v4
         with:
           ref: jazzy-devel

--- a/.github/workflows/kilted-devel.yaml
+++ b/.github/workflows/kilted-devel.yaml
@@ -17,7 +17,7 @@ jobs:
       image: ubuntu:noble
     steps:
       - name: Install popf deps
-        run: sudo apt-get install libfl-dev
+        run: apt-get update && apt-get install libfl-dev
       - uses: actions/checkout@v4
         with:
           ref: kilted-devel

--- a/.github/workflows/kilted-devel.yaml
+++ b/.github/workflows/kilted-devel.yaml
@@ -9,26 +9,26 @@ on:
       - kilted-devel
   schedule:
       - cron: '0 0 * * 6'
+  workflow_dispatch:
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4
+        with:
+          ref: kilted-devel
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: kilted-devel
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal plansys2_tests plansys2_tools
-          target-ros2-distro: kilted-devel
+          ref: kilted-devel
+          target-ros2-distro: kilted
           colcon-defaults: |
             {
               "test": {
@@ -39,9 +39,10 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella
           # yml: ./codecov.yml
+          fail_ci_if_error: false

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install popf deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libfl-dev
+        run: apt-get update && apt-get install -y libfl-dev
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
       - name: build and test

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -9,13 +9,12 @@ on:
       - rolling
   schedule:
       - cron: '0 0 * * 6'
+  workflow_dispatch:
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
       - name: Install popf deps
@@ -24,8 +23,6 @@ jobs:
           sudo apt-get install -y libfl-dev
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
@@ -41,9 +38,10 @@ jobs:
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella
           # yml: ./codecov.yml
+          fail_ci_if_error: false


### PR DESCRIPTION
There is an issue with apt-get in bare metal GitHub actions workers when using the [setup-ros action](https://github.com/ros-tooling/setup-ros#overview), so they recommend using the container workers.

This PR migrates the execution from bare metal workers to containers. It also removes the CI matrix setup because it had only one variant.

Additionally, I added a `workflow_dispatch` event so the CI actions can be manually trigger from Gitub's interface (this has to be migrated to the other branches for it to work there).

Please let me know if you are ok with the changes or if we should change anything else (like the scheduled runs for jazzy/kilted).
