### PR TITLE
Fix rqt plugins thread safety, spurious node warning, and executor performer hang

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
@@ -100,18 +100,31 @@ ActionExecutor::action_hub_callback(plansys2_msgs::msg::ActionExecution::SharedP
       if (last_msg_->arguments == action_params_ &&
         last_msg_->action == action_name_ && last_msg_->node_id == current_performer_id_)
       {
-        if (last_msg_->success) {
-          state_ = SUCCESS;
-        } else {
-          state_ = FAILURE;
-        }
-
         feedback_ = last_msg_->status;
         completion_ = last_msg_->completion;
-
         state_time_ = node_->now();
 
-        action_hub_pub_->on_deactivate();
+        if (last_msg_->success) {
+          state_ = SUCCESS;
+          action_hub_pub_->on_deactivate();
+        } else if (last_msg_->completion == 0.0) {
+          // Performer failed before doing any work (likely activation failure) - retry
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Performer [%s] for action [%s] failed before starting. Retrying.",
+            current_performer_id_.c_str(), action_.c_str());
+          current_performer_id_ = "";
+          state_ = DEALING;
+          state_time_ = node_->now();
+          completion_ = 0.0;
+          feedback_ = "";
+          request_for_performers();
+          waiting_timer_ = node_->create_wall_timer(
+            1s, std::bind(&ActionExecutor::wait_timeout, this));
+        } else {
+          state_ = FAILURE;
+          action_hub_pub_->on_deactivate();
+        }
       }
       break;
     default:
@@ -217,6 +230,25 @@ ActionExecutor::tick(const rclcpp::Time & now)
       break;
 
     case RUNNING:
+      {
+        // If the confirmed performer never sends any feedback within 5 seconds, it likely
+        // failed silently (e.g. activation error not reported). Retry with a new request.
+        auto elapsed_no_feedback = (node_->now() - state_time_).seconds();
+        if (elapsed_no_feedback > 5.0 && completion_ == 0.0) {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Performer [%s] for action [%s] never sent feedback after 5s. Retrying.",
+            current_performer_id_.c_str(), action_.c_str());
+          current_performer_id_ = "";
+          state_ = DEALING;
+          state_time_ = node_->now();
+          completion_ = 0.0;
+          feedback_ = "";
+          request_for_performers();
+          waiting_timer_ = node_->create_wall_timer(
+            1s, std::bind(&ActionExecutor::wait_timeout, this));
+        }
+      }
       break;
     case SUCCESS:
     case FAILURE:

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -147,6 +147,14 @@ ActionExecutorClient::action_hub_callback(const plansys2_msgs::msg::ActionExecut
         current_arguments_ = msg->arguments;
         trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
         committed_ = false;
+        // If activation failed, notify the executor so it can retry with another performer
+        if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+          RCLCPP_ERROR(
+            get_logger(),
+            "Performer [%s] failed to activate for action [%s]. Notifying executor.",
+            get_name(), action_managed_.c_str());
+          finish(false, 0.0, "Activation failed for performer " + std::string(get_name()));
+        }
       }
       break;
     case plansys2_msgs::msg::ActionExecution::REJECT:

--- a/plansys2_tools/include/rqt_plansys2_knowledge/RQTKnowledge.hpp
+++ b/plansys2_tools/include/rqt_plansys2_knowledge/RQTKnowledge.hpp
@@ -28,6 +28,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)
@@ -74,6 +75,7 @@ private:
 
   plansys2_msgs::msg::Knowledge::UniquePtr last_msg_;
   bool need_repaint_;
+  std::mutex mutex_;
 
   void knowledge_callback(plansys2_msgs::msg::Knowledge::UniquePtr msg);
   rclcpp::Subscription<plansys2_msgs::msg::Knowledge>::SharedPtr knowledge_sub_;

--- a/plansys2_tools/include/rqt_plansys2_performers/RQTPerformers.hpp
+++ b/plansys2_tools/include/rqt_plansys2_performers/RQTPerformers.hpp
@@ -28,6 +28,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "rclcpp/version.h"
@@ -38,7 +39,6 @@
 #endif
 
 #include "rqt_plansys2_performers/PerformersTree.hpp"
-#include "plansys2_problem_expert/ProblemExpertClient.hpp"
 
 #include "plansys2_msgs/msg/action_performer_status.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -76,8 +76,7 @@ private:
   std::map<std::string, plansys2_msgs::msg::ActionPerformerStatus::UniquePtr> performers_info_;
   rclcpp::Subscription<plansys2_msgs::msg::ActionPerformerStatus>::SharedPtr performers_sub_;
   bool need_update_;
-
-  std::shared_ptr<plansys2::ProblemExpertClient> problem_;
+  std::mutex mutex_;
 
   void performers_callback(plansys2_msgs::msg::ActionPerformerStatus::UniquePtr msg);
   std::optional<QTreeWidgetItem *> get_performer_line(const std::string & performer_name);

--- a/plansys2_tools/include/rqt_plansys2_plan/RQTPlan.hpp
+++ b/plansys2_tools/include/rqt_plansys2_plan/RQTPlan.hpp
@@ -28,6 +28,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "rclcpp/version.h"
@@ -82,6 +83,7 @@ private:
   rclcpp::Subscription<plansys2_msgs::msg::Plan>::SharedPtr executing_plan_;
   bool need_update_plan_;
   bool need_update_info_;
+  std::mutex mutex_;
 
   void execution_info_callback(plansys2_msgs::msg::ActionExecutionInfo::UniquePtr msg);
   void plan_callback(plansys2_msgs::msg::Plan::UniquePtr msg);

--- a/plansys2_tools/src/rqt_plansys2_knowledge/RQTKnowledge.cpp
+++ b/plansys2_tools/src/rqt_plansys2_knowledge/RQTKnowledge.cpp
@@ -82,6 +82,7 @@ void RQTKnowledge::shutdownPlugin()
 void
 RQTKnowledge::knowledge_callback(plansys2_msgs::msg::Knowledge::UniquePtr msg)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   last_msg_ = std::move(msg);
   need_repaint_ = true;
 }
@@ -97,73 +98,78 @@ RQTKnowledge::saveSettings(
 void
 RQTKnowledge::spin_loop()
 {
-  if (need_repaint_) {
-    knowledge_tree_->clearAllItems();
-
-    // Instances
-    for (const std::string & instance : last_msg_->instances) {
-      auto instance_item = new QTreeWidgetItem();
-      instance_item->setText(0, QString("instance"));
-      instance_item->setText(1, QString(instance.c_str()));
-
-      auto complete_instance = problem_->getInstance(instance);
-      if (complete_instance.has_value()) {
-        instance_item->setText(2, QString(complete_instance.value().type.c_str()));
-      }
-
-      instance_item->setBackground(0, Qt::lightGray);
-      instance_item->setBackground(1, Qt::lightGray);
-      instance_item->setBackground(2, Qt::lightGray);
-      knowledge_tree_->addTopLevelItem(instance_item);
-    }
-
-    // Predicates
-    for (const std::string & predicate : last_msg_->predicates) {
-      auto predicate_item = new QTreeWidgetItem();
-      predicate_item->setText(0, QString("predicate"));
-      predicate_item->setText(1, QString(predicate.c_str()));
-      predicate_item->setBackground(0, Qt::yellow);
-      predicate_item->setBackground(1, Qt::yellow);
-      predicate_item->setBackground(2, Qt::yellow);
-      knowledge_tree_->addTopLevelItem(predicate_item);
-    }
-
-    // Functions (Value?)
-    for (const std::string & function : last_msg_->functions) {
-      auto function_item = new QTreeWidgetItem();
-      function_item->setText(0, QString("function"));
-      function_item->setText(1, QString(function.c_str()));
-
-      auto complete_function = problem_->getFunction(function);
-      if (complete_function.has_value()) {
-        function_item->setText(2, QString::number(complete_function.value().value));
-      }
-
-      function_item->setBackground(0, Qt::blue);
-      function_item->setBackground(1, Qt::blue);
-      function_item->setBackground(2, Qt::blue);
-      knowledge_tree_->addTopLevelItem(function_item);
-    }
-
-    // Goal
-    auto goal_item = new QTreeWidgetItem();
-    goal_item->setText(0, QString("goal"));
-    if (last_msg_->goal == "") {
-      goal_item->setText(1, QString("No goal"));
-      goal_item->setBackground(0, Qt::red);
-      goal_item->setBackground(1, Qt::red);
-      goal_item->setBackground(2, Qt::red);
-    } else {
-      goal_item->setText(1, QString(last_msg_->goal.c_str()));
-      goal_item->setBackground(0, Qt::green);
-      goal_item->setBackground(1, Qt::green);
-      goal_item->setBackground(2, Qt::green);
-    }
-    knowledge_tree_->addTopLevelItem(goal_item);
-
-    knowledge_tree_->parentWidget()->repaint();
-    need_repaint_ = false;
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!need_repaint_) {
+    return;
   }
+  need_repaint_ = false;
+  auto msg_snapshot = std::move(last_msg_);
+  lock.unlock();
+
+  knowledge_tree_->clearAllItems();
+
+  // Instances
+  for (const std::string & instance : msg_snapshot->instances) {
+    auto instance_item = new QTreeWidgetItem();
+    instance_item->setText(0, QString("instance"));
+    instance_item->setText(1, QString(instance.c_str()));
+
+    auto complete_instance = problem_->getInstance(instance);
+    if (complete_instance.has_value()) {
+      instance_item->setText(2, QString(complete_instance.value().type.c_str()));
+    }
+
+    instance_item->setBackground(0, Qt::lightGray);
+    instance_item->setBackground(1, Qt::lightGray);
+    instance_item->setBackground(2, Qt::lightGray);
+    knowledge_tree_->addTopLevelItem(instance_item);
+  }
+
+  // Predicates
+  for (const std::string & predicate : msg_snapshot->predicates) {
+    auto predicate_item = new QTreeWidgetItem();
+    predicate_item->setText(0, QString("predicate"));
+    predicate_item->setText(1, QString(predicate.c_str()));
+    predicate_item->setBackground(0, Qt::yellow);
+    predicate_item->setBackground(1, Qt::yellow);
+    predicate_item->setBackground(2, Qt::yellow);
+    knowledge_tree_->addTopLevelItem(predicate_item);
+  }
+
+  // Functions (Value?)
+  for (const std::string & function : msg_snapshot->functions) {
+    auto function_item = new QTreeWidgetItem();
+    function_item->setText(0, QString("function"));
+    function_item->setText(1, QString(function.c_str()));
+
+    auto complete_function = problem_->getFunction(function);
+    if (complete_function.has_value()) {
+      function_item->setText(2, QString::number(complete_function.value().value));
+    }
+
+    function_item->setBackground(0, Qt::blue);
+    function_item->setBackground(1, Qt::blue);
+    function_item->setBackground(2, Qt::blue);
+    knowledge_tree_->addTopLevelItem(function_item);
+  }
+
+  // Goal
+  auto goal_item = new QTreeWidgetItem();
+  goal_item->setText(0, QString("goal"));
+  if (msg_snapshot->goal == "") {
+    goal_item->setText(1, QString("No goal"));
+    goal_item->setBackground(0, Qt::red);
+    goal_item->setBackground(1, Qt::red);
+    goal_item->setBackground(2, Qt::red);
+  } else {
+    goal_item->setText(1, QString(msg_snapshot->goal.c_str()));
+    goal_item->setBackground(0, Qt::green);
+    goal_item->setBackground(1, Qt::green);
+    goal_item->setBackground(2, Qt::green);
+  }
+  knowledge_tree_->addTopLevelItem(goal_item);
+
+  knowledge_tree_->parentWidget()->repaint();
 }
 
 void

--- a/plansys2_tools/src/rqt_plansys2_performers/RQTPerformers.cpp
+++ b/plansys2_tools/src/rqt_plansys2_performers/RQTPerformers.cpp
@@ -30,9 +30,6 @@
 #include "rqt_plansys2_performers/RQTPerformers.hpp"
 #include "rqt_plansys2_performers/PerformersTree.hpp"
 
-
-#include "plansys2_problem_expert/ProblemExpertClient.hpp"
-
 namespace rqt_plansys2_performers
 {
 
@@ -73,8 +70,6 @@ void RQTPerformers::initPlugin(qt_gui_cpp::PluginContext & context)
   performers_sub_ = node_->create_subscription<plansys2_msgs::msg::ActionPerformerStatus>(
     "performers_status", rclcpp::QoS(100).reliable(),
     std::bind(&RQTPerformers::performers_callback, this, _1));
-
-  problem_ = std::make_shared<plansys2::ProblemExpertClient>();
 }
 
 void RQTPerformers::shutdownPlugin()
@@ -84,6 +79,7 @@ void RQTPerformers::shutdownPlugin()
 void
 RQTPerformers::performers_callback(plansys2_msgs::msg::ActionPerformerStatus::UniquePtr msg)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   performers_info_[msg->node_name] = std::move(msg);
   need_update_ = true;
 }
@@ -153,7 +149,7 @@ RQTPerformers::add_new_row(const plansys2_msgs::msg::ActionPerformerStatus & per
   for (const auto & arg : performer.specialized_arguments) {
     join_args = join_args + " : " + arg;
   }
-  join_args.erase(0, 1);  // remove first ":"
+  join_args.erase(0, 3);  // remove leading " : "
 
   instance_item->setText(4, QString(join_args.c_str()));
 
@@ -163,6 +159,7 @@ RQTPerformers::add_new_row(const plansys2_msgs::msg::ActionPerformerStatus & per
 void
 RQTPerformers::spin_loop()
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (!need_update_) {
     return;
   }

--- a/plansys2_tools/src/rqt_plansys2_plan/RQTPlan.cpp
+++ b/plansys2_tools/src/rqt_plansys2_plan/RQTPlan.cpp
@@ -85,6 +85,7 @@ void RQTPlan::shutdownPlugin()
 void
 RQTPlan::execution_info_callback(plansys2_msgs::msg::ActionExecutionInfo::UniquePtr msg)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (!need_update_plan_) {
     plan_info_[msg->action_full_name] = std::move(msg);
     need_update_info_ = true;
@@ -94,6 +95,7 @@ RQTPlan::execution_info_callback(plansys2_msgs::msg::ActionExecutionInfo::Unique
 void
 RQTPlan::plan_callback(plansys2_msgs::msg::Plan::UniquePtr msg)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (plan_ == nullptr || *plan_ != *msg) {
     new_plan_ = std::move(msg);
     need_update_plan_ = true;
@@ -186,10 +188,12 @@ RQTPlan::fill_row_info(
 void
 RQTPlan::spin_loop()
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (!need_update_info_ && !need_update_plan_) {
     return;
   }
 
+  bool was_plan_updated = false;
   if (need_update_plan_) {
     plan_ = std::move(new_plan_);
 
@@ -202,9 +206,16 @@ RQTPlan::spin_loop()
 
     need_update_info_ = true;
     need_update_plan_ = false;
+    was_plan_updated = true;
+  }
 
+  bool do_update_info = need_update_info_;
+  if (do_update_info) {
+    need_update_info_ = false;
+  }
+
+  if (was_plan_updated && plan_) {
     plan_tree_->clearAllItems();
-
     for (const auto & item : plan_->items) {
       auto plan_item = new QTreeWidgetItem();
       std::string full_name = item.action + ":" +
@@ -214,17 +225,16 @@ RQTPlan::spin_loop()
     }
   }
 
-  if (need_update_info_) {
-    need_update_info_ = false;
-
+  if (do_update_info && plan_) {
     for (const auto & item : plan_->items) {
       std::string full_name = item.action + ":" +
         std::to_string(static_cast<int>(item.time * 1000));
 
       auto item_row = get_plan_item_row(full_name);
       if (item_row.has_value()) {
-        if (plan_info_.find(full_name) != plan_info_.end() && plan_info_[full_name] != nullptr) {
-          fill_row_info(item_row.value(), *(plan_info_[full_name]));
+        auto it = plan_info_.find(full_name);
+        if (it != plan_info_.end() && it->second != nullptr) {
+          fill_row_info(item_row.value(), *(it->second));
         }
       }
     }


### PR DESCRIPTION
Hi,

This PR fixes a couple of bugs just detected:

### Root cause

The plan stalled with one action stuck at `EXECUTING / completion=0.0 / 0.00/5.00s`
while all subsequent actions remained `NOT_EXECUTED`. Analysis of `/actions_hub` showed
that the affected action received `CONFIRM(3)` + `REJECT(4)` to the other candidates,
but the confirmed performer never emitted `FEEDBACK(5)` or `FINISH(6)`, leaving the
executor blocked in `RUNNING` with no way out.

---

### `plansys2_tools` — rqt plugins

#### `rqt_plansys2_knowledge`
- Added `std::mutex` to protect `last_msg_` and `need_repaint_` between the ROS
  subscription callback (executor thread) and `spin_loop()` (Qt main thread). The
  absence of synchronization caused data races that triggered
  `eprosima::fastcdr::exception::BadParamException` and process crashes.

#### `rqt_plansys2_performers`
- Removed unused `std::shared_ptr<plansys2::ProblemExpertClient> problem_` member.
  `ProblemExpertClient` creates an internal node with the hardcoded name
  `"problem_expert_client"`, and since `RQTKnowledge` also instantiates one, having
  both plugins loaded simultaneously produced: `[WARN] Publisher already registered for node name: 'problem_expert_client'`
- Added `std::mutex` to protect `performers_info_` and `need_update_` between the
ROS callback and `spin_loop()`.
- Fixed `join_args.erase(0, 1)` → `erase(0, 3)` in `add_new_row()`: the loop builds
a string prefixed with `" : "` (3 chars), not just `":"`.

#### `rqt_plansys2_plan`
- Added `std::mutex` to protect `plan_info_`, `new_plan_`, `plan_`,
`need_update_plan_` and `need_update_info_` between the ROS callbacks and
`spin_loop()`.

---

### `plansys2_executor` — performer hang fix

#### `ActionExecutorClient.cpp`
After receiving `CONFIRM` and calling `trigger_transition(ACTIVATE)`, the node now
checks whether it actually reached `PRIMARY_STATE_ACTIVE`. If activation failed (e.g.
`BTAction::on_activate` threw an exception during BT tree recreation),
`finish(false, 0.0, ...)` is published to `actions_hub` so the executor can react
immediately instead of waiting forever.

#### `ActionExecutor.cpp`
Two changes to prevent the executor from hanging indefinitely in state `RUNNING`:

1. **Silent performer failure retry**: if the confirmed performer reports `FINISH` with
 `success=false` and `completion=0.0` (failed before doing any work), the executor
 re-enters `DEALING` and re-issues a `REQUEST` instead of failing the whole plan.

2. **No-feedback timeout**: if the executor has been in `RUNNING` for more than 5
 seconds and `completion_` is still `0.0` (performer confirmed but never sent any
 `FEEDBACK`), the executor re-enters `DEALING` and retries. This handles the case
 where the performer crashes silently after activation without publishing any message.

I hope it helps