### PR TITLE
Fix missing module in plansys2_tui dependencies

### DIFF
--- a/plansys2_tui_cli/package.xml
+++ b/plansys2_tui_cli/package.xml
@@ -16,6 +16,7 @@
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>python3-rich</exec_depend>
+  <exec_depend>python3-platformdirs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/plansys2_tui_cli/test/test_entrypoints.py
+++ b/plansys2_tui_cli/test/test_entrypoints.py
@@ -1,0 +1,35 @@
+import unittest
+from importlib.metadata import entry_points
+
+
+class TestConsoleEntryPoints(unittest.TestCase):
+    def test_plansys2_tui_entrypoint_loads(self):
+        eps = entry_points(group="console_scripts", name="plansys2_tui")
+        ep = next(iter(eps), None)
+
+        self.assertIsNotNone(
+            ep,
+            "Console script 'plansys2_tui' is not registered in console_scripts.",
+        )
+        self.assertEqual(
+            ep.value,
+            "plansys2_tui_cli.tui.app:run_app",
+            "The 'plansys2_tui' entry point points to an unexpected target.",
+        )
+
+        try:
+            loaded = ep.load()
+        except Exception as exc:
+            self.fail(
+                "Failed to load the 'plansys2_tui' entry point: "
+                f"{type(exc).__name__}: {exc}"
+            )
+
+        self.assertTrue(
+            callable(loaded),
+            "The loaded 'plansys2_tui' entry point is not callable.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes https://github.com/PlanSys2/ros2_planning_system/issues/403#issue-4095654290 related to a missing dep in `plansys2_tui`.