### PR TITLE
Rolling pr duplicated nodes names

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -63,6 +63,13 @@ public:
   DomainExpertClient();
 
   /**
+   * @brief Construct a new DomainExpertClient object with a given node name.
+   *
+   * @param node_name Name of the ROS2 node.
+   */
+  DomainExpertClient(const std::string & node_name);
+
+  /**
    * @brief Get the name of the domain.
    *
    * @return std::string The name of the domain.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -67,7 +67,7 @@ public:
    *
    * @param node_name Name of the ROS2 node.
    */
-  DomainExpertClient(const std::string & node_name);
+  explicit DomainExpertClient(const std::string & node_name);
 
   /**
    * @brief Get the name of the domain.

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -24,9 +24,12 @@
 namespace plansys2
 {
 
-DomainExpertClient::DomainExpertClient()
+DomainExpertClient::DomainExpertClient() : DomainExpertClient("domain_expert_client") {}
+
+DomainExpertClient::DomainExpertClient(const std::string & node_name)
 {
-  node_ = rclcpp::Node::make_shared("domain_expert_client");
+  auto options = rclcpp::NodeOptions().use_global_arguments(false);
+  node_ = rclcpp::Node::make_shared(node_name, options);
 
   get_domain_client_ = node_->create_client<plansys2_msgs::srv::GetDomain>(
     "domain_expert/get_domain");

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -24,7 +24,8 @@
 namespace plansys2
 {
 
-DomainExpertClient::DomainExpertClient() : DomainExpertClient("domain_expert_client") {}
+DomainExpertClient::DomainExpertClient()
+: DomainExpertClient("domain_expert_client") {}
 
 DomainExpertClient::DomainExpertClient(const std::string & node_name)
 {

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -153,9 +153,11 @@ ComputeBT::on_configure(const rclcpp_lifecycle::State & state)
   planner_node_ = std::make_shared<plansys2::PlannerNode>();
   problem_node_ = std::make_shared<plansys2::ProblemExpertNode>();
 
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("compute_bt_domain_expert_client");
+  domain_client_ =
+    std::make_shared<plansys2::DomainExpertClient>("compute_bt_domain_expert_client");
   planner_client_ = std::make_shared<plansys2::PlannerClient>("compute_bt_planner_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("compute_bt_problem_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("compute_bt_problem_expert_client");
 
   RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());
   return CallbackReturnT::SUCCESS;

--- a/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
+++ b/plansys2_executor/src/plansys2_executor/ComputeBT.cpp
@@ -153,9 +153,9 @@ ComputeBT::on_configure(const rclcpp_lifecycle::State & state)
   planner_node_ = std::make_shared<plansys2::PlannerNode>();
   problem_node_ = std::make_shared<plansys2::ProblemExpertNode>();
 
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  planner_client_ = std::make_shared<plansys2::PlannerClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("compute_bt_domain_expert_client");
+  planner_client_ = std::make_shared<plansys2::PlannerClient>("compute_bt_planner_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("compute_bt_problem_expert_client");
 
   RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());
   return CallbackReturnT::SUCCESS;

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -44,7 +44,8 @@ ExecutorClient::ExecutorClient()
 
 ExecutorClient::ExecutorClient(const std::string & node_name)
 {
-  node_ = rclcpp::Node::make_shared(node_name);
+  auto options = rclcpp::NodeOptions().use_global_arguments(false);
+  node_ = rclcpp::Node::make_shared(node_name, options);
 
   createActionClient();
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -196,9 +196,9 @@ ExecutorNode::on_configure(const rclcpp_lifecycle::State & state)
   remaining_plan_pub_ = create_publisher<plansys2_msgs::msg::Plan>(
     "remaining_plan", rclcpp::QoS(100));
 
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
-  planner_client_ = std::make_shared<plansys2::PlannerClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("executor_domain_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("executor_problem_expert_client");
+  planner_client_ = std::make_shared<plansys2::PlannerClient>("executor_planner_client");
 
   RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());
   return CallbackReturnT::SUCCESS;

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -197,7 +197,8 @@ ExecutorNode::on_configure(const rclcpp_lifecycle::State & state)
     "remaining_plan", rclcpp::QoS(100));
 
   domain_client_ = std::make_shared<plansys2::DomainExpertClient>("executor_domain_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("executor_problem_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("executor_problem_expert_client");
   planner_client_ = std::make_shared<plansys2::PlannerClient>("executor_planner_client");
 
   RCLCPP_INFO(get_logger(), "[%s] Configured", get_name());

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/sequential_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/sequential_bt_builder.cpp
@@ -19,8 +19,10 @@ namespace plansys2
 
 SequentialBTBuilder::SequentialBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("sequential_bt_builder_domain_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("sequential_bt_builder_problem_expert_client");
+  domain_client_ =
+    std::make_shared<plansys2::DomainExpertClient>("sequential_bt_builder_domain_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("sequential_bt_builder_problem_expert_client");
 }
 
 void SequentialBTBuilder::initialize(

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/sequential_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/sequential_bt_builder.cpp
@@ -19,8 +19,8 @@ namespace plansys2
 
 SequentialBTBuilder::SequentialBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("sequential_bt_builder_domain_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("sequential_bt_builder_problem_expert_client");
 }
 
 void SequentialBTBuilder::initialize(

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -36,8 +36,10 @@ namespace plansys2
 
 SimpleBTBuilder::SimpleBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("simple_bt_builder_domain_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("simple_bt_builder_problem_expert_client");
+  domain_client_ =
+    std::make_shared<plansys2::DomainExpertClient>("simple_bt_builder_domain_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("simple_bt_builder_problem_expert_client");
 }
 
 void

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -36,8 +36,8 @@ namespace plansys2
 
 SimpleBTBuilder::SimpleBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("simple_bt_builder_domain_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("simple_bt_builder_problem_expert_client");
 }
 
 void

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
@@ -33,8 +33,10 @@ namespace plansys2
 
 STNBTBuilder::STNBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("stn_bt_builder_domain_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("stn_bt_builder_problem_expert_client");
+  domain_client_ =
+    std::make_shared<plansys2::DomainExpertClient>("stn_bt_builder_domain_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("stn_bt_builder_problem_expert_client");
 }
 
 void

--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/stn_bt_builder.cpp
@@ -33,8 +33,8 @@ namespace plansys2
 
 STNBTBuilder::STNBTBuilder()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("stn_bt_builder_domain_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("stn_bt_builder_problem_expert_client");
 }
 
 void

--- a/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
+++ b/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
@@ -55,7 +55,7 @@ public:
    * Creates a ROS node and configures service clients to connect to
    * the planner services. Also retrieves the plan_solver_timeout parameter.
    */
-  PlannerClient(const std::string & node_name);
+  explicit PlannerClient(const std::string & node_name);
 
   /**
    * @brief Generate a single plan for a PDDL planning problem.

--- a/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
+++ b/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
@@ -48,6 +48,16 @@ public:
   PlannerClient();
 
   /**
+   * @brief Constructor for the PlannerClient with a given node name.
+   *
+   * @param node_name Name of the ROS2 node.
+   *
+   * Creates a ROS node and configures service clients to connect to
+   * the planner services. Also retrieves the plan_solver_timeout parameter.
+   */
+  PlannerClient(const std::string & node_name);
+
+  /**
    * @brief Generate a single plan for a PDDL planning problem.
    *
    * @param[in] domain PDDL domain definition as a string.

--- a/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
@@ -23,13 +23,14 @@
 namespace plansys2
 {
 
-PlannerClient::PlannerClient(): PlannerClient("planner_client"){}
+PlannerClient::PlannerClient()
+: PlannerClient("planner_client") {}
 
 PlannerClient::PlannerClient(const std::string & node_name)
 {
   auto options = rclcpp::NodeOptions().use_global_arguments(false);
   node_ = rclcpp::Node::make_shared(node_name, options);
-  
+
   get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("planner/get_plan");
   get_plan_array_client_ = node_->create_client<plansys2_msgs::srv::GetPlanArray>(
     "planner/get_plan_array");

--- a/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
@@ -23,10 +23,13 @@
 namespace plansys2
 {
 
-PlannerClient::PlannerClient()
-{
-  node_ = rclcpp::Node::make_shared("planner_client");
+PlannerClient::PlannerClient(): PlannerClient("planner_client"){}
 
+PlannerClient::PlannerClient(const std::string & node_name)
+{
+  auto options = rclcpp::NodeOptions().use_global_arguments(false);
+  node_ = rclcpp::Node::make_shared(node_name, options);
+  
   get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("planner/get_plan");
   get_plan_array_client_ = node_->create_client<plansys2_msgs::srv::GetPlanArray>(
     "planner/get_plan_array");

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
@@ -66,6 +66,13 @@ public:
   ProblemExpertClient();
 
   /**
+   * @brief Constructor for the ProblemExpertClient with a given node name.
+   *
+   * @param node_name Name of the ROS2 node.
+   */
+  ProblemExpertClient(const std::string & node_name);
+
+  /**
    * @brief Get all instances in the problem.
    *
    * @return std::vector<plansys2::Instance> Vector containing all instances in the problem.

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
@@ -70,7 +70,7 @@ public:
    *
    * @param node_name Name of the ROS2 node.
    */
-  ProblemExpertClient(const std::string & node_name);
+  explicit ProblemExpertClient(const std::string & node_name);
 
   /**
    * @brief Get all instances in the problem.

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
@@ -25,9 +25,12 @@
 namespace plansys2
 {
 
-ProblemExpertClient::ProblemExpertClient()
+ProblemExpertClient::ProblemExpertClient(): ProblemExpertClient("problem_expert_client"){}
+
+ProblemExpertClient::ProblemExpertClient(const std::string & node_name)
 {
-  node_ = rclcpp::Node::make_shared("problem_expert_client");
+  auto options = rclcpp::NodeOptions().use_global_arguments(false);
+  node_ = rclcpp::Node::make_shared(node_name, options);
 
   add_problem_client_ = node_->create_client<plansys2_msgs::srv::AddProblem>(
     "problem_expert/add_problem");

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
@@ -25,7 +25,8 @@
 namespace plansys2
 {
 
-ProblemExpertClient::ProblemExpertClient(): ProblemExpertClient("problem_expert_client"){}
+ProblemExpertClient::ProblemExpertClient()
+: ProblemExpertClient("problem_expert_client") {}
 
 ProblemExpertClient::ProblemExpertClient(const std::string & node_name)
 {

--- a/plansys2_support_py/plansys2_support_py/DomainExpertClient.py
+++ b/plansys2_support_py/plansys2_support_py/DomainExpertClient.py
@@ -61,7 +61,7 @@ class DomainExpertClient(Node):
             Namespace prefix for services.
 
         """
-        super().__init__(node_name)
+        super().__init__(node_name, use_global_arguments=False)
 
         # Setup namespace prefix
         self._namespace_prefix = f'/{namespace}' if namespace else ''

--- a/plansys2_support_py/plansys2_support_py/ExecutorClient.py
+++ b/plansys2_support_py/plansys2_support_py/ExecutorClient.py
@@ -69,10 +69,17 @@ class ExecutorClient(Node):
             f'{self._namespace_prefix}/execute_plan'
         )
 
+        PREFIX = 'executor_client_py'
         # Create clients for domain, problem, and planner
-        self._domain_client = DomainExpertClient("executor_client_py_domain_expert_client", namespace=namespace)
-        self._problem_client = ProblemExpertClient("executor_client_py_problem_expert_client", namespace=namespace)
-        self._planner_client = PlannerClient("executor_client_py_planner_client", namespace=namespace)
+        self._domain_client = DomainExpertClient(
+                                f'{PREFIX}_domain_expert_client',
+                                namespace=namespace)
+        self._problem_client = ProblemExpertClient(
+                                f'{PREFIX}_problem_expert_client',
+                                namespace=namespace)
+        self._planner_client = PlannerClient(
+                                f'{PREFIX}_planner_client',
+                                namespace=namespace)
 
         self.get_logger().debug(f'Executor Client "{node_name}" initialized')
 

--- a/plansys2_support_py/plansys2_support_py/ExecutorClient.py
+++ b/plansys2_support_py/plansys2_support_py/ExecutorClient.py
@@ -57,7 +57,7 @@ class ExecutorClient(Node):
             Namespace prefix for services.
 
         """
-        super().__init__(node_name)
+        super().__init__(node_name, use_global_arguments=False)
 
         # Setup namespace prefix
         self._namespace_prefix = f'/{namespace}' if namespace else ''
@@ -70,9 +70,9 @@ class ExecutorClient(Node):
         )
 
         # Create clients for domain, problem, and planner
-        self._domain_client = DomainExpertClient(namespace=namespace)
-        self._problem_client = ProblemExpertClient(namespace=namespace)
-        self._planner_client = PlannerClient(namespace=namespace)
+        self._domain_client = DomainExpertClient("executor_client_py_domain_expert_client", namespace=namespace)
+        self._problem_client = ProblemExpertClient("executor_client_py_problem_expert_client", namespace=namespace)
+        self._planner_client = PlannerClient("executor_client_py_planner_client", namespace=namespace)
 
         self.get_logger().debug(f'Executor Client "{node_name}" initialized')
 

--- a/plansys2_support_py/plansys2_support_py/Parser.py
+++ b/plansys2_support_py/plansys2_support_py/Parser.py
@@ -46,8 +46,10 @@ class Parser:
             The reduced expression.
 
         """
+        # Remove PDDL comments: from ';' to end of line
+        result = re.sub(r';[^\n\r]*', '', expr)
         # Remove newlines and tabs
-        result = re.sub(r'[\n\t]+', '', expr)
+        result = re.sub(r'[\n\t]+', '', result)
         # Replace multiple spaces with single space
         result = re.sub(r' +', ' ', result)
         # Remove space after opening parenthesis

--- a/plansys2_support_py/plansys2_support_py/PlannerClient.py
+++ b/plansys2_support_py/plansys2_support_py/PlannerClient.py
@@ -49,7 +49,7 @@ class PlannerClient(Node):
             Namespace prefix for services.
 
         """
-        super().__init__(node_name)
+        super().__init__(node_name, use_global_arguments=False)
 
         # Setup namespace prefix
         self._namespace_prefix = f'/{namespace}' if namespace else ''

--- a/plansys2_support_py/plansys2_support_py/ProblemExpertClient.py
+++ b/plansys2_support_py/plansys2_support_py/ProblemExpertClient.py
@@ -56,7 +56,7 @@ class ProblemExpertClient(Node):
             Namespace prefix for services.
 
         """
-        super().__init__(node_name)
+        super().__init__(node_name, use_global_arguments=False)
         self._namespace_prefix = f'/{namespace}' if namespace else ''
         self.get_logger().debug(f'Problem Expert Client "{node_name}" initialized')
 

--- a/plansys2_support_py/test/test_parser.py
+++ b/plansys2_support_py/test/test_parser.py
@@ -62,6 +62,13 @@ class TestParser(unittest.TestCase):
         result = Parser.get_reduced_string(expr)
         self.assertEqual(result, '(and (robot_at r1 wp1) (carrying r1 obj1))')
 
+    def test_get_reduced_string_with_comments(self):
+        """Test that comments are removed without losing subsequent content."""
+        expr = '(and (robot_at r1 wp1) ; this is a comment\n (carrying r1 obj1))'
+        result = Parser.get_reduced_string(expr)
+        self.assertNotIn(';', result)
+        self.assertEqual(result, '(and (robot_at r1 wp1) (carrying r1 obj1))')
+
     def test_get_node_type_and(self):
         """Test detection of AND node type."""
         expr = '(and (p1) (p2))'

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -230,7 +230,8 @@ void
 Terminal::init()
 {
   domain_client_ = std::make_shared<plansys2::DomainExpertClient>("terminal_domain_expert_client");
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("terminal_problem_expert_client");
+  problem_client_ =
+    std::make_shared<plansys2::ProblemExpertClient>("terminal_problem_expert_client");
   planner_client_ = std::make_shared<plansys2::PlannerClient>("terminal_planner_client");
   executor_client_ = std::make_shared<plansys2::ExecutorClient>("terminal_executor_client");
 

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -229,10 +229,10 @@ Terminal::Terminal(const rclcpp::NodeOptions & options)
 void
 Terminal::init()
 {
-  domain_client_ = std::make_shared<plansys2::DomainExpertClient>();
-  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>();
-  planner_client_ = std::make_shared<plansys2::PlannerClient>();
-  executor_client_ = std::make_shared<plansys2::ExecutorClient>();
+  domain_client_ = std::make_shared<plansys2::DomainExpertClient>("terminal_domain_expert_client");
+  problem_client_ = std::make_shared<plansys2::ProblemExpertClient>("terminal_problem_expert_client");
+  planner_client_ = std::make_shared<plansys2::PlannerClient>("terminal_planner_client");
+  executor_client_ = std::make_shared<plansys2::ExecutorClient>("terminal_executor_client");
 
   add_problem();
 }


### PR DESCRIPTION
Hi @fmrico,

while I am doing some tests I noticed an issue we had some time ago with multi-robot experiments related to the node name duplication issue described in #381, particularly affecting `domain_expert_client` and `problem_expert_client`.
In this pull request, I propose an approach to avoid the situation where multiple nodes have the same name.

<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/0ea85c74-dffe-49d7-82de-54c8b15fa42f" />


## Problem
When client nodes are instantiated as class attributes, they inherit global arguments and end up sharing the same node name as the parent node. This leads to multiple nodes with identical names in the ROS graph, which can cause unexpected behavior.

## Proposed solution
This PR introduces two changes:

1. **Disable global arguments for internal nodes**  
   Both C++ and Python client implementations now explicitly disable global arguments when creating internal nodes, preventing unintended name reuse.

2. **Explicit naming for client nodes**  
   Added constructors that allow specifying node names.  
   Internal client nodes are now named using the pattern: `{external_node_name}_{internal_node_name}`. Let me know if this approach works for you, or if you would prefer `{internal_node_name}_{external_node_name}` to group all `domain_expert_client` / `problem_expert_client` nodes. I am also open to exploring alternative approaches if you think there are better ways to avoid this proliferation of duplicate nodes. I was also thinking about whether it might be a good idea to mark them as hidden nodes by using an underscore as a node name prefix, as they might be more confusing than helpful (view all `domain/problem_expert_client` nodes), let me know what you think.  
This ensures uniqueness and improves graph readability.

Example result:
- No duplicated node names
- Clear association between external node and its internal clients
<img width="300" height="300" alt="Screenshot from 2026-04-07 11-44-44" src="https://github.com/user-attachments/assets/bb7d3f64-c4c8-4d47-bdf6-535d78c580c1" />

## Additional changes
- Python parser: ignore comments inside PDDL expressions to avoid parsing issues
- ~~a minor adjustment in the use of `ament_index_cpp::get_package_share_directory` in `ComputeBT` and `ExecutorNode` to improve cross-compatibility between ROS versions (verified with Jazzy).~~  I removed this changes, as I noticed I re-introduces the warnings that was already addressed in https://github.com/PlanSys2/ros2_planning_system/issues/397#issue-4056957698. Nevertheless, that is the only aspect that makes the rolling release incompatible with Jazzy. What do you think about introducing a utility/wrapper function to make it cross-compatible?

Thanks!