### PR TITLE
msgs: deal with CMake `CMP0094`

### DIFF
--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(plansys2_msgs)
 


### PR DESCRIPTION
Bump CMake minimum version to `3.15`, as that's where `CMP0094` was introduced.

CMake versions lower than `3.15` have trouble locating Python in environments where a Python installed in a non-default location should be used (such as Conda, Pixi, etc).
